### PR TITLE
update examples for wheel

### DIFF
--- a/examples/calibration.py
+++ b/examples/calibration.py
@@ -2,8 +2,10 @@
 
 import asyncio
 
+from mavsdk import start_mavlink
 from mavsdk import connect as mavsdk_connect
 
+start_mavlink()
 drone = mavsdk_connect(host="127.0.0.1")
 
 

--- a/examples/camera.py
+++ b/examples/camera.py
@@ -2,9 +2,11 @@
 
 import asyncio
 
+from mavsdk import start_mavlink
 from mavsdk import connect as mavsdk_connect
 from mavsdk import (CameraError, CameraMode)
 
+start_mavlink()
 drone = mavsdk_connect(host="127.0.0.1")
 
 

--- a/examples/firmware_version.py
+++ b/examples/firmware_version.py
@@ -2,8 +2,10 @@
 
 import asyncio
 
+from mavsdk import start_mavlink
 from mavsdk import connect as mavsdk_connect
 
+start_mavlink()
 drone = mavsdk_connect(host="127.0.0.1")
 
 

--- a/examples/mission.py
+++ b/examples/mission.py
@@ -2,9 +2,11 @@
 
 import asyncio
 
+from mavsdk import start_mavlink
 from mavsdk import connect as mavsdk_connect
 from mavsdk import (MissionItem)
 
+start_mavlink()
 drone = mavsdk_connect(host="127.0.0.1")
 
 

--- a/examples/offboard.py
+++ b/examples/offboard.py
@@ -14,6 +14,7 @@ Some caveats when attempting to run the examples in non-gps environments:
 
 import asyncio
 
+from mavsdk import start_mavlink
 from mavsdk import connect as mavsdk_connect
 from mavsdk import (
     Attitude,
@@ -23,6 +24,7 @@ from mavsdk import (
     VelocityNEDYaw,
 )
 
+start_mavlink()
 drone = mavsdk_connect(host="127.0.0.1")
 
 

--- a/examples/takeoff_and_land.py
+++ b/examples/takeoff_and_land.py
@@ -2,8 +2,10 @@
 
 import asyncio
 
+from mavsdk import start_mavlink
 from mavsdk import connect as mavsdk_connect
 
+start_mavlink()
 drone = mavsdk_connect(host="127.0.0.1")
 
 

--- a/examples/telemetry.py
+++ b/examples/telemetry.py
@@ -2,8 +2,10 @@
 
 import asyncio
 
+from mavsdk import start_mavlink
 from mavsdk import connect as mavsdk_connect
 
+start_mavlink()
 drone = mavsdk_connect(host="127.0.0.1")
 
 

--- a/examples/telemetry_flight_mode.py
+++ b/examples/telemetry_flight_mode.py
@@ -2,8 +2,10 @@
 
 import asyncio
 
+from mavsdk import start_mavlink
 from mavsdk import connect as mavsdk_connect
 
+start_mavlink()
 drone = mavsdk_connect(host="127.0.0.1")
 
 

--- a/examples/telemetry_is_armed_is_in_air.py
+++ b/examples/telemetry_is_armed_is_in_air.py
@@ -2,8 +2,10 @@
 
 import asyncio
 
+from mavsdk import start_mavlink
 from mavsdk import connect as mavsdk_connect
 
+start_mavlink()
 drone = mavsdk_connect(host="127.0.0.1")
 
 

--- a/examples/telemetry_takeoff_and_land.py
+++ b/examples/telemetry_takeoff_and_land.py
@@ -2,8 +2,10 @@
 
 import asyncio
 
+from mavsdk import start_mavlink
 from mavsdk import connect as mavsdk_connect
 
+start_mavlink()
 drone = mavsdk_connect(host="127.0.0.1")
 
 async def run():


### PR DESCRIPTION
From now on, we assume that users install our wheel package (`pip3 install mavsdk`) that contains `mavsdk_server` as a binary. The examples should therefore reflect that, by starting `mavsdk_server` at the beginning of the scripts:

```python
from mavsdk import start_mavlink
start_mavlink()
```