### PR TITLE
add macos to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ class custom_build(build):
         """
         if sys.platform.startswith('linux'):
             return 'manylinux1-x64'
+        elif sys.platform.startswith('darwin'):
+            return 'macos'
         else:
             raise NotImplementedError(
                 f"Platform {sys.platform} is not (yet) supported by this setup.py!")


### PR DESCRIPTION
Tested to work on my computer, and released to pypi.

@julianoes: can you try to `pip3 install mavsdk` on a mac and check that you get version `0.2.0`?