### PR TITLE
Fix for primitive types array rpc-gen template

### DIFF
--- a/other/templates/struct.j2
+++ b/other/templates/struct.j2
@@ -56,9 +56,8 @@ class {{ name.upper_camel_case }}:
         {% for field in fields %}
         {% if field.type_info.is_repeated %}
             {% if field.type_info.is_primitive %}
-        rpc_elems_list = []
         for elem in self.{{ field.name.lower_snake_case}}:
-          rpc_elems_list.append(elem)
+          rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}.append(elem)
             {% else %}
         rpc_elems_list = []
         for elem in self.{{ field.name.lower_snake_case }}:


### PR DESCRIPTION
This is fix for [this PR](https://github.com/mavlink/MAVSDK-Python/pull/76).
I checked this fix on offboard.setActuatorControl() request. For this request all works ok but at this time I can not say that it will work for everything else.
I apologize for wrong implementation.