### PR TITLE
Fix mission download

### DIFF
--- a/mavsdk/generated/core.py
+++ b/mavsdk/generated/core.py
@@ -227,5 +227,9 @@ class Core(AsyncBase):
 
         
 
-        return [PluginInfo].translate_from_rpc(response.plugin_info)
-        
+        plugin_info = []
+        for plugin_info_rpc in response.plugin_info:
+            plugin_info.append(PluginInfo.translate_from_rpc(plugin_info_rpc))
+
+        return plugin_info
+            

--- a/mavsdk/generated/mission.py
+++ b/mavsdk/generated/mission.py
@@ -631,8 +631,12 @@ class Mission(AsyncBase):
             raise MissionError(result, "download_mission()")
         
 
-        return [MissionItem].translate_from_rpc(response.mission_items)
-        
+        mission_items = []
+        for mission_items_rpc in response.mission_items:
+            mission_items.append(MissionItem.translate_from_rpc(mission_items_rpc))
+
+        return mission_items
+            
 
     async def cancel_mission_download(self):
         """

--- a/other/templates/request.j2
+++ b/other/templates/request.j2
@@ -53,5 +53,13 @@ async def {{ name.lower_snake_case }}(self{% for param in params %}, {{ param.na
     {% if return_type.is_primitive -%}
     return response.{{ return_name.lower_snake_case }}
     {% else -%}
-    return {{ return_type.name }}.translate_from_rpc(response.{{ return_name.lower_snake_case }})
+        {% if return_type.is_repeated -%}
+    {{ return_name.lower_snake_case }} = []
+    for {{ return_name.lower_snake_case }}_rpc in response.{{ return_name.lower_snake_case }}:
+        {{ return_name.lower_snake_case }}.append({{ return_type.inner_name }}.translate_from_rpc({{ return_name.lower_snake_case }}_rpc))
+
+    return {{ return_name.lower_snake_case }}
+        {% else -%}
+    return {{ return_type.inner_name }}.translate_from_rpc(response.{{ return_name.lower_snake_case }})
+        {% endif -%}
     {% endif %}


### PR DESCRIPTION
The templates were incorrect regarding returning a `repeated` type in a request (typically `download_mission()`). This PR addresses it.

@petergerten: would you mind reviewing this (possibly testing it)?

Resolves #138.