### PR TITLE
examples: extend calibration.py with other calibration routines

### DIFF
--- a/examples/calibration.py
+++ b/examples/calibration.py
@@ -9,9 +9,25 @@ async def run():
     drone = System()
     await drone.connect(system_address="udp://:14540")
 
-    print("-- Starting gyro calibration")
+    print("-- Starting gyroscope calibration")
     async for progress_data in drone.calibration.calibrate_gyro():
         print(progress_data)
+    print("-- Gyroscope calibration finished")
+
+    print("-- Starting accelerometer calibration")
+    async for progress_data in drone.calibration.calibrate_accelerometer():
+        print(progress_data)
+    print("-- Accelerometer calibration finished")
+
+    print("-- Starting magnetometer calibration")
+    async for progress_data in drone.calibration.calibrate_magnetometer():
+        print(progress_data)
+    print("-- Magnetometer calibration finished")
+
+    print("-- Starting board level horizon calibration")
+    async for progress_data in drone.calibration.calibrate_level_horizon():
+        print(progress_data)
+    print("-- Board level calibration finished")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I decided to extend the example. Although, something weird seems to happen with the progress status text parsing during the accel calibration:
```sh
$ python3 calibration.py 
Waiting for mavsdk_server to be ready...
Connected to mavsdk_server!
-- Starting gyroscope calibration
ProgressData: [has_progress: True, progress: 0.0, has_status_text: False, status_text: ]
ProgressData: [has_progress: True, progress: 0.03999999910593033, has_status_text: False, status_text: ]
ProgressData: [has_progress: True, progress: 0.09000000357627869, has_status_text: False, status_text: ]
ProgressData: [has_progress: True, progress: 0.14000000059604645, has_status_text: False, status_text: ]
ProgressData: [has_progress: True, progress: 0.1899999976158142, has_status_text: False, status_text: ]
ProgressData: [has_progress: True, progress: 0.9100000262260437, has_status_text: False, status_text: ]
ProgressData: [has_progress: True, progress: 0.9599999785423279, has_status_text: False, status_text: ]
-- Gyroscope calibration finished
-- Starting accelerometer calibration
ProgressData: [has_progress: True, progress: 0.0, has_status_text: False, status_text: ]
ProgressData: [has_progress: False, progress: nan, has_status_text: True, status_text: pending: back front left right up down]
ProgressData: [has_progress: False, progress: nan, has_status_text: True, status_text: hold vehicle still on a pending side]
ProgressData: [has_progress: False, progress: nan, has_status_text: True, status_text: detected rest position, hold still...]
ProgressData: [has_progress: False, progress: nan, has_status_text: True, status_text: down orientation detected]
ProgressData: [has_progress: False, progress: nan, has_status_text: True, status_text: down orientation detected]
ProgressData: [has_progress: False, progress: nan, has_status_text: True, status_text: Hold still, measuring down side]
[libprotobuf ERROR google/protobuf/wire_format_lite.cc:577] String field 'mavsdk.rpc.calibration.ProgressData.status_text' contains invalid UTF-8 data when parsing a protocol buffer. Use the 'bytes' type if you intend to send raw bytes. 
Traceback (most recent call last):
  File "calibration.py", line 35, in <module>
    loop.run_until_complete(run())
  File "/usr/lib/python3.6/asyncio/base_events.py", line 484, in run_until_complete
    return future.result()
  File "calibration.py", line 18, in run
    async for progress_data in drone.calibration.calibrate_accelerometer():
  File "/home/nuno/Client_Projects/TealDrones/MAVSDK-Python/mavsdk/generated/calibration.py", line 389, in calibrate_accelerometer
    async for response in calibrate_accelerometer_stream:
  File "/home/nuno/.local/lib/python3.6/site-packages/aiogrpc/utils.py", line 138, in __anext__
    return await asyncio.shield(self._next_future, loop=self._loop)
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/nuno/.local/lib/python3.6/site-packages/aiogrpc/utils.py", line 126, in _next
    return next(self._iterator)
  File "/home/nuno/.local/lib/python3.6/site-packages/grpc/_channel.py", line 416, in __next__
    return self._next()
  File "/home/nuno/.local/lib/python3.6/site-packages/grpc/_channel.py", line 706, in _next
    raise self
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.INTERNAL
	details = "Exception deserializing response!"
	debug_error_string = "None"
```

(Btw, the level horizon calibration works fine @JonasVautherin)