### PR TITLE
Publish pure wheel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,23 @@ matrix:
   fast_finish: true
   include:
   - os: linux
+    name: linux (pure wheel)
+    dist: bionic
+    python:
+    - 3.6
+    - 3.7
+    before_install:
+      python3 --version;
+      pip3 --version;
+    env:
+    - BUILD_TARGET=linux_pure_wheel
+    - PYTHON_BIN=python3
+    - MAVSDK_BUILD_PURE=ON
+    addons:
+      apt:
+        packages:
+        - patchelf
+  - os: linux
     name: Linux
     dist: bionic
     python:
@@ -66,6 +83,10 @@ install:
 script:
 - set -e
 - $PYTHON_BIN setup.py bdist_wheel
+- if [[ "${BUILD_TARGET}" = "linux_pure_wheel" ]]; then
+    mkdir wheelhouse;
+    mv dist/*.whl wheelhouse;
+  fi
 - if [[ "${BUILD_TARGET}" = "linux" ]]; then
     auditwheel repair --plat manylinux2010_x86_64 dist/*.whl;
   fi

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -162,14 +162,18 @@ class System:
         else:
             from importlib_resources import path
 
-        with path(bin, 'mavsdk_server') as backend:
-            bin_path_and_args = [os.fspath(backend), "-p", "50051"]
-            if system_address:
-                bin_path_and_args.append(system_address)
-            p = subprocess.Popen(bin_path_and_args,
-                                 shell=False,
-                                 stdout=subprocess.DEVNULL,
-                                 stderr=subprocess.DEVNULL)
+        try:
+            with path(bin, 'mavsdk_server') as backend:
+                bin_path_and_args = [os.fspath(backend), "-p", "50051"]
+                if system_address:
+                    bin_path_and_args.append(system_address)
+                p = subprocess.Popen(bin_path_and_args,
+                                     shell=False,
+                                     stdout=subprocess.DEVNULL,
+                                     stderr=subprocess.DEVNULL)
+        except FileNotFoundError:
+            raise Exception("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n\t1. Build 'mavsdk_server': https://github.com/mavlink/mavsdk.\n\t2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n\t3. Set the 'mavsdk_server_address' and port when creating the System: 'drone = System(mavsdk_server_address='localhost', port=50051)\n")
+
 
         def cleanup():
             p.kill()

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from os import path, getcwd
 
 import urllib.request
 import os
+import platform
 import stat
 import sys
 import subprocess
@@ -52,7 +53,7 @@ class custom_build(build):
         """
         Trying to detect the platform to know which `mavsdk_server` executable to download
         """
-        if sys.platform.startswith('linux'):
+        if sys.platform.startswith('linux') and platform.machine() == "x86_64":
             return 'manylinux2010-x64'
         elif sys.platform.startswith('darwin'):
             return 'macos'
@@ -60,7 +61,7 @@ class custom_build(build):
             return 'win32.exe'
         else:
             raise NotImplementedError(
-                f"Platform {sys.platform} is not (yet) supported by this setup.py!")
+                f"Error: mavsdk_server is not distributed for platform {sys.platform} (yet)! You should set the 'MAVSDK_BUILD_PURE=ON' environment variable and get mavsdk_server manually.")
 
     @property
     def mavsdk_server_filepath(self):
@@ -86,7 +87,9 @@ class custom_build(build):
         return f"https://github.com/mavlink/MAVSDK/releases/download/{self.mavsdk_server_tag}/mavsdk_server_{self.platform_suffix}"
 
     def run(self):
-        self.download_mavsdk_server()
+        if 'MAVSDK_BUILD_PURE' not in os.environ:
+            self.download_mavsdk_server()
+
         build.run(self)
 
     def download_mavsdk_server(self):

--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ setup(
     cmdclass={'build': custom_build},
 
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Running `MAVSDK_BUILD_PURE=ON python setup.py bdist_wheel` now creates a pure wheel that does not embed `mavsdk_server`. Travis publishes it to PyPi.

I had found a nicer solution not involving an env variable (it was `python setup.py build --pure`), but it did not work with `python setup.py bdist_wheel` :slightly_frowning_face:.