### PR TITLE
Fix translate_to_rpc for enums

### DIFF
--- a/mavsdk/generated/action.py
+++ b/mavsdk/generated/action.py
@@ -78,7 +78,7 @@ class ActionResult:
         NO_VTOL_TRANSITION_SUPPORT = 10
         PARAMETER_ERROR = 11
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == ActionResult.Result.UNKNOWN:
                 return action_pb2.ActionResult.RESULT_UNKNOWN
             if self == ActionResult.Result.SUCCESS:
@@ -182,7 +182,7 @@ class ActionResult:
         
         
             
-        self.result.translate_to_rpc(rpcActionResult.result)
+        rpcActionResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/calibration.py
+++ b/mavsdk/generated/calibration.py
@@ -74,7 +74,7 @@ class CalibrationResult:
         CANCELLED = 9
         FAILED_ARMED = 10
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == CalibrationResult.Result.UNKNOWN:
                 return calibration_pb2.CalibrationResult.RESULT_UNKNOWN
             if self == CalibrationResult.Result.SUCCESS:
@@ -174,7 +174,7 @@ class CalibrationResult:
         
         
             
-        self.result.translate_to_rpc(rpcCalibrationResult.result)
+        rpcCalibrationResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/camera.py
+++ b/mavsdk/generated/camera.py
@@ -26,7 +26,7 @@ class Mode(Enum):
     PHOTO = 1
     VIDEO = 2
 
-    def translate_to_rpc(self, rpcMode):
+    def translate_to_rpc(self):
         if self == Mode.UNKNOWN:
             return camera_pb2.MODE_UNKNOWN
         if self == Mode.PHOTO:
@@ -106,7 +106,7 @@ class CameraResult:
         TIMEOUT = 6
         WRONG_ARGUMENT = 7
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == CameraResult.Result.UNKNOWN:
                 return camera_pb2.CameraResult.RESULT_UNKNOWN
             if self == CameraResult.Result.SUCCESS:
@@ -194,7 +194,7 @@ class CameraResult:
         
         
             
-        self.result.translate_to_rpc(rpcCameraResult.result)
+        rpcCameraResult.result = self.result.translate_to_rpc()
             
         
         
@@ -846,7 +846,7 @@ class VideoStreamInfo:
         NOT_RUNNING = 0
         IN_PROGRESS = 1
 
-        def translate_to_rpc(self, rpcStatus):
+        def translate_to_rpc(self):
             if self == VideoStreamInfo.Status.NOT_RUNNING:
                 return camera_pb2.VideoStreamInfo.STATUS_NOT_RUNNING
             if self == VideoStreamInfo.Status.IN_PROGRESS:
@@ -916,7 +916,7 @@ class VideoStreamInfo:
         
         
             
-        self.status.translate_to_rpc(rpcVideoStreamInfo.status)
+        rpcVideoStreamInfo.status = self.status.translate_to_rpc()
             
         
         
@@ -978,7 +978,7 @@ class Status:
         UNFORMATTED = 1
         FORMATTED = 2
 
-        def translate_to_rpc(self, rpcStorageStatus):
+        def translate_to_rpc(self):
             if self == Status.StorageStatus.NOT_AVAILABLE:
                 return camera_pb2.Status.STORAGE_STATUS_NOT_AVAILABLE
             if self == Status.StorageStatus.UNFORMATTED:
@@ -1130,7 +1130,7 @@ class Status:
         
         
             
-        self.storage_status.translate_to_rpc(rpcStatus.storage_status)
+        rpcStatus.storage_status = self.storage_status.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/follow_me.py
+++ b/mavsdk/generated/follow_me.py
@@ -56,7 +56,7 @@ class Config:
         FRONT_RIGHT = 3
         FRONT_LEFT = 4
 
-        def translate_to_rpc(self, rpcFollowDirection):
+        def translate_to_rpc(self):
             if self == Config.FollowDirection.NONE:
                 return follow_me_pb2.Config.FOLLOW_DIRECTION_NONE
             if self == Config.FollowDirection.BEHIND:
@@ -158,7 +158,7 @@ class Config:
         
         
             
-        self.follow_direction.translate_to_rpc(rpcConfig.follow_direction)
+        rpcConfig.follow_direction = self.follow_direction.translate_to_rpc()
             
         
         
@@ -370,7 +370,7 @@ class FollowMeResult:
         NOT_ACTIVE = 7
         SET_CONFIG_FAILED = 8
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == FollowMeResult.Result.UNKNOWN:
                 return follow_me_pb2.FollowMeResult.RESULT_UNKNOWN
             if self == FollowMeResult.Result.SUCCESS:
@@ -462,7 +462,7 @@ class FollowMeResult:
         
         
             
-        self.result.translate_to_rpc(rpcFollowMeResult.result)
+        rpcFollowMeResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/ftp.py
+++ b/mavsdk/generated/ftp.py
@@ -152,7 +152,7 @@ class FtpResult:
         UNSUPPORTED = 10
         PROTOCOL_ERROR = 11
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == FtpResult.Result.UNKNOWN:
                 return ftp_pb2.FtpResult.RESULT_UNKNOWN
             if self == FtpResult.Result.SUCCESS:
@@ -256,7 +256,7 @@ class FtpResult:
         
         
             
-        self.result.translate_to_rpc(rpcFtpResult.result)
+        rpcFtpResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/geofence.py
+++ b/mavsdk/generated/geofence.py
@@ -112,7 +112,7 @@ class Polygon:
         INCLUSION = 0
         EXCLUSION = 1
 
-        def translate_to_rpc(self, rpcType):
+        def translate_to_rpc(self):
             if self == Polygon.Type.INCLUSION:
                 return geofence_pb2.Polygon.TYPE_INCLUSION
             if self == Polygon.Type.EXCLUSION:
@@ -187,7 +187,7 @@ class Polygon:
         
         
             
-        self.type.translate_to_rpc(rpcPolygon.type)
+        rpcPolygon.type = self.type.translate_to_rpc()
             
         
         
@@ -247,7 +247,7 @@ class GeofenceResult:
         TIMEOUT = 5
         INVALID_ARGUMENT = 6
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == GeofenceResult.Result.UNKNOWN:
                 return geofence_pb2.GeofenceResult.RESULT_UNKNOWN
             if self == GeofenceResult.Result.SUCCESS:
@@ -331,7 +331,7 @@ class GeofenceResult:
         
         
             
-        self.result.translate_to_rpc(rpcGeofenceResult.result)
+        rpcGeofenceResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/gimbal.py
+++ b/mavsdk/generated/gimbal.py
@@ -22,7 +22,7 @@ class GimbalMode(Enum):
     YAW_FOLLOW = 0
     YAW_LOCK = 1
 
-    def translate_to_rpc(self, rpcGimbalMode):
+    def translate_to_rpc(self):
         if self == GimbalMode.YAW_FOLLOW:
             return gimbal_pb2.GIMBAL_MODE_YAW_FOLLOW
         if self == GimbalMode.YAW_LOCK:
@@ -82,7 +82,7 @@ class GimbalResult:
         ERROR = 2
         TIMEOUT = 3
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == GimbalResult.Result.UNKNOWN:
                 return gimbal_pb2.GimbalResult.RESULT_UNKNOWN
             if self == GimbalResult.Result.SUCCESS:
@@ -154,7 +154,7 @@ class GimbalResult:
         
         
             
-        self.result.translate_to_rpc(rpcGimbalResult.result)
+        rpcGimbalResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/info.py
+++ b/mavsdk/generated/info.py
@@ -498,7 +498,7 @@ class InfoResult:
         SUCCESS = 1
         INFORMATION_NOT_RECEIVED_YET = 2
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == InfoResult.Result.UNKNOWN:
                 return info_pb2.InfoResult.RESULT_UNKNOWN
             if self == InfoResult.Result.SUCCESS:
@@ -566,7 +566,7 @@ class InfoResult:
         
         
             
-        self.result.translate_to_rpc(rpcInfoResult.result)
+        rpcInfoResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/log_files.py
+++ b/mavsdk/generated/log_files.py
@@ -206,7 +206,7 @@ class LogFilesResult:
         INVALID_ARGUMENT = 5
         FILE_OPEN_FAILED = 6
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == LogFilesResult.Result.UNKNOWN:
                 return log_files_pb2.LogFilesResult.RESULT_UNKNOWN
             if self == LogFilesResult.Result.SUCCESS:
@@ -290,7 +290,7 @@ class LogFilesResult:
         
         
             
-        self.result.translate_to_rpc(rpcLogFilesResult.result)
+        rpcLogFilesResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/mission.py
+++ b/mavsdk/generated/mission.py
@@ -83,7 +83,7 @@ class MissionItem:
         START_VIDEO = 4
         STOP_VIDEO = 5
 
-        def translate_to_rpc(self, rpcCameraAction):
+        def translate_to_rpc(self):
             if self == MissionItem.CameraAction.NONE:
                 return mission_pb2.MissionItem.CAMERA_ACTION_NONE
             if self == MissionItem.CameraAction.TAKE_PHOTO:
@@ -261,7 +261,7 @@ class MissionItem:
         
         
             
-        self.camera_action.translate_to_rpc(rpcMissionItem.camera_action)
+        rpcMissionItem.camera_action = self.camera_action.translate_to_rpc()
             
         
         
@@ -494,7 +494,7 @@ class MissionResult:
         UNSUPPORTED_MISSION_CMD = 11
         TRANSFER_CANCELLED = 12
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == MissionResult.Result.UNKNOWN:
                 return mission_pb2.MissionResult.RESULT_UNKNOWN
             if self == MissionResult.Result.SUCCESS:
@@ -602,7 +602,7 @@ class MissionResult:
         
         
             
-        self.result.translate_to_rpc(rpcMissionResult.result)
+        rpcMissionResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/mission_raw.py
+++ b/mavsdk/generated/mission_raw.py
@@ -394,7 +394,7 @@ class MissionRawResult:
         NO_MISSION_AVAILABLE = 8
         TRANSFER_CANCELLED = 9
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == MissionRawResult.Result.UNKNOWN:
                 return mission_raw_pb2.MissionRawResult.RESULT_UNKNOWN
             if self == MissionRawResult.Result.SUCCESS:
@@ -490,7 +490,7 @@ class MissionRawResult:
         
         
             
-        self.result.translate_to_rpc(rpcMissionRawResult.result)
+        rpcMissionRawResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/mocap.py
+++ b/mavsdk/generated/mocap.py
@@ -803,7 +803,7 @@ class Odometry:
         MOCAP_NED = 0
         LOCAL_FRD = 1
 
-        def translate_to_rpc(self, rpcMavFrame):
+        def translate_to_rpc(self):
             if self == Odometry.MavFrame.MOCAP_NED:
                 return mocap_pb2.Odometry.MAV_FRAME_MOCAP_NED
             if self == Odometry.MavFrame.LOCAL_FRD:
@@ -915,7 +915,7 @@ class Odometry:
         
         
             
-        self.frame_id.translate_to_rpc(rpcOdometry.frame_id)
+        rpcOdometry.frame_id = self.frame_id.translate_to_rpc()
             
         
         
@@ -1003,7 +1003,7 @@ class MocapResult:
         CONNECTION_ERROR = 3
         INVALID_REQUEST_DATA = 4
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == MocapResult.Result.UNKNOWN:
                 return mocap_pb2.MocapResult.RESULT_UNKNOWN
             if self == MocapResult.Result.SUCCESS:
@@ -1079,7 +1079,7 @@ class MocapResult:
         
         
             
-        self.result.translate_to_rpc(rpcMocapResult.result)
+        rpcMocapResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/offboard.py
+++ b/mavsdk/generated/offboard.py
@@ -729,7 +729,7 @@ class OffboardResult:
         TIMEOUT = 6
         NO_SETPOINT_SET = 7
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == OffboardResult.Result.UNKNOWN:
                 return offboard_pb2.OffboardResult.RESULT_UNKNOWN
             if self == OffboardResult.Result.SUCCESS:
@@ -817,7 +817,7 @@ class OffboardResult:
         
         
             
-        self.result.translate_to_rpc(rpcOffboardResult.result)
+        rpcOffboardResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/param.py
+++ b/mavsdk/generated/param.py
@@ -54,7 +54,7 @@ class ParamResult:
         WRONG_TYPE = 4
         PARAM_NAME_TOO_LONG = 5
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == ParamResult.Result.UNKNOWN:
                 return param_pb2.ParamResult.RESULT_UNKNOWN
             if self == ParamResult.Result.SUCCESS:
@@ -134,7 +134,7 @@ class ParamResult:
         
         
             
-        self.result.translate_to_rpc(rpcParamResult.result)
+        rpcParamResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/shell.py
+++ b/mavsdk/generated/shell.py
@@ -54,7 +54,7 @@ class ShellResult:
         NO_RESPONSE = 4
         BUSY = 5
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == ShellResult.Result.UNKNOWN:
                 return shell_pb2.ShellResult.RESULT_UNKNOWN
             if self == ShellResult.Result.SUCCESS:
@@ -134,7 +134,7 @@ class ShellResult:
         
         
             
-        self.result.translate_to_rpc(rpcShellResult.result)
+        rpcShellResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/telemetry.py
+++ b/mavsdk/generated/telemetry.py
@@ -42,7 +42,7 @@ class FixType(Enum):
     RTK_FLOAT = 5
     RTK_FIXED = 6
 
-    def translate_to_rpc(self, rpcFixType):
+    def translate_to_rpc(self):
         if self == FixType.NO_GPS:
             return telemetry_pb2.FIX_TYPE_NO_GPS
         if self == FixType.NO_FIX:
@@ -153,7 +153,7 @@ class FlightMode(Enum):
     STABILIZED = 13
     RATTITUDE = 14
 
-    def translate_to_rpc(self, rpcFlightMode):
+    def translate_to_rpc(self):
         if self == FlightMode.UNKNOWN:
             return telemetry_pb2.FLIGHT_MODE_UNKNOWN
         if self == FlightMode.READY:
@@ -245,7 +245,7 @@ class StatusTextType(Enum):
     WARNING = 1
     CRITICAL = 2
 
-    def translate_to_rpc(self, rpcStatusTextType):
+    def translate_to_rpc(self):
         if self == StatusTextType.INFO:
             return telemetry_pb2.STATUS_TEXT_TYPE_INFO
         if self == StatusTextType.WARNING:
@@ -297,7 +297,7 @@ class LandedState(Enum):
     TAKING_OFF = 3
     LANDING = 4
 
-    def translate_to_rpc(self, rpcLandedState):
+    def translate_to_rpc(self):
         if self == LandedState.UNKNOWN:
             return telemetry_pb2.LANDED_STATE_UNKNOWN
         if self == LandedState.ON_GROUND:
@@ -799,7 +799,7 @@ class GpsInfo:
         
         
             
-        self.fix_type.translate_to_rpc(rpcGpsInfo.fix_type)
+        rpcGpsInfo.fix_type = self.fix_type.translate_to_rpc()
             
         
         
@@ -1185,7 +1185,7 @@ class StatusText:
         
         
             
-        self.type.translate_to_rpc(rpcStatusText.type)
+        rpcStatusText.type = self.type.translate_to_rpc()
             
         
         
@@ -1653,7 +1653,7 @@ class Odometry:
         VISION_NED = 2
         ESTIM_NED = 3
 
-        def translate_to_rpc(self, rpcMavFrame):
+        def translate_to_rpc(self):
             if self == Odometry.MavFrame.UNDEF:
                 return telemetry_pb2.Odometry.MAV_FRAME_UNDEF
             if self == Odometry.MavFrame.BODY_NED:
@@ -1780,13 +1780,13 @@ class Odometry:
         
         
             
-        self.frame_id.translate_to_rpc(rpcOdometry.frame_id)
+        rpcOdometry.frame_id = self.frame_id.translate_to_rpc()
             
         
         
         
             
-        self.child_frame_id.translate_to_rpc(rpcOdometry.child_frame_id)
+        rpcOdometry.child_frame_id = self.child_frame_id.translate_to_rpc()
             
         
         
@@ -2692,7 +2692,7 @@ class TelemetryResult:
         COMMAND_DENIED = 5
         TIMEOUT = 6
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == TelemetryResult.Result.UNKNOWN:
                 return telemetry_pb2.TelemetryResult.RESULT_UNKNOWN
             if self == TelemetryResult.Result.SUCCESS:
@@ -2776,7 +2776,7 @@ class TelemetryResult:
         
         
             
-        self.result.translate_to_rpc(rpcTelemetryResult.result)
+        rpcTelemetryResult.result = self.result.translate_to_rpc()
             
         
         

--- a/mavsdk/generated/tune.py
+++ b/mavsdk/generated/tune.py
@@ -98,7 +98,7 @@ class SongElement(Enum):
     OCTAVE_UP = 19
     OCTAVE_DOWN = 20
 
-    def translate_to_rpc(self, rpcSongElement):
+    def translate_to_rpc(self):
         if self == SongElement.STYLE_LEGATO:
             return tune_pb2.SONG_ELEMENT_STYLE_LEGATO
         if self == SongElement.STYLE_NORMAL:
@@ -313,7 +313,7 @@ class TuneResult:
         TUNE_TOO_LONG = 2
         ERROR = 3
 
-        def translate_to_rpc(self, rpcResult):
+        def translate_to_rpc(self):
             if self == TuneResult.Result.SUCCESS:
                 return tune_pb2.TuneResult.RESULT_SUCCESS
             if self == TuneResult.Result.INVALID_TEMPO:
@@ -385,7 +385,7 @@ class TuneResult:
         
         
             
-        self.result.translate_to_rpc(rpcTuneResult.result)
+        rpcTuneResult.result = self.result.translate_to_rpc()
             
         
         

--- a/other/templates/enum.j2
+++ b/other/templates/enum.j2
@@ -14,7 +14,7 @@ class {{ name.upper_camel_case }}(Enum):
     {{ value.name.uppercase }} = {{ loop.index - 1 }}
     {%- endfor %}
 
-    def translate_to_rpc(self, rpc{{ name.upper_camel_case }}):
+    def translate_to_rpc(self):
         {%- for value in values %}
         if self == {% if parent_struct is not none %}{{ parent_struct.upper_camel_case }}.{% endif %}{{ name.upper_camel_case }}.{{ value.name.uppercase }}:
             return {{ plugin_name.lower_snake_case }}_pb2.{% if parent_struct is not none %}{{ parent_struct.upper_camel_case }}.{% endif %}{{ name.uppercase }}_{{ value.name.uppercase }}

--- a/other/templates/struct.j2
+++ b/other/templates/struct.j2
@@ -78,6 +78,8 @@ class {{ name.upper_camel_case }}:
         {% else %}
             {% if field.type_info.is_primitive %}
         rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }} = self.{{ field.name.lower_snake_case }}
+            {% elif field.type_info.is_enum %}
+        rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }} = self.{{ field.name.lower_snake_case }}.translate_to_rpc()
             {% else %}
         self.{{ field.name.lower_snake_case}}.translate_to_rpc(rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }})
             {% endif %}


### PR DESCRIPTION
`translate_to_rpc` called for an enum from the `translate_to_rpc` of a struct had no effect, and was hence resulting in conversions.

It was not reported before because we don't really often use enums as parameters.