### PR TITLE
Improve instructions for unsupported architectures

### DIFF
--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -91,112 +91,117 @@ class System:
         for plugin in self._core_plugins:
             self._plugins[plugin.lower()] = globals()[plugin](plugin_manager)
 
+    @staticmethod
+    def error_uninitialized(plugin_name: str) -> str:
+        return "{plugin_name} plugin has not been initialized!" \
+            "Did you run `System.connect()`?"
+
     @property
     def action(self) -> Action:
         if "action" not in self._plugins:
-            raise RuntimeError("Action plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Action"))
         return self._plugins["action"]
 
     @property
     def calibration(self) -> Calibration:
         if "calibration" not in self._plugins:
-            raise RuntimeError("Calibration plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Calibration"))
         return self._plugins["calibration"]
 
     @property
     def camera(self) -> Camera:
         if "camera" not in self._plugins:
-            raise RuntimeError("Camera plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Camera"))
         return self._plugins["camera"]
 
     @property
     def core(self) -> Core:
         if "core" not in self._plugins:
-            raise RuntimeError("Core plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Core"))
         return self._plugins["core"]
 
     @property
     def follow_me(self) -> FollowMe:
         if "follow_me" not in self._plugins:
-            raise RuntimeError("FollowMe plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("FollowMe"))
         return self._plugins["follow_me"]
 
     @property
     def ftp(self) -> Ftp:
         if "ftp" not in self._plugins:
-            raise RuntimeError("Ftp plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Ftp"))
         return self._plugins["Ftp"]
 
     @property
     def geofence(self) -> Geofence:
         if "geofence" not in self._plugins:
-            raise RuntimeError("Geofence plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Geofence"))
         return self._plugins["geofence"]
 
     @property
     def gimbal(self) -> Gimbal:
         if "gimbal" not in self._plugins:
-            raise RuntimeError("Gimbal plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Gimbal"))
         return self._plugins["gimbal"]
 
     @property
     def info(self) -> Info:
         if "info" not in self._plugins:
-            raise RuntimeError("Info plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Info"))
         return self._plugins["info"]
 
     @property
     def log_files(self) -> LogFiles:
         if "log_files" not in self._plugins:
-            raise RuntimeError("LogFiles plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("LogFiles"))
         return self._plugins["log_files"]
 
     @property
     def mission(self) -> Mission:
         if "mission" not in self._plugins:
-            raise RuntimeError("Mission plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Mission"))
         return self._plugins["mission"]
 
     @property
     def mission_raw(self) -> MissionRaw:
         if "mission_raw" not in self._plugins:
-            raise RuntimeError("MissionRaw plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("MissionRaw"))
         return self._plugins["mission_raw"]
 
     @property
     def mocap(self) -> Mocap:
         if "mocap" not in self._plugins:
-            raise RuntimeError("Mocap plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Mocap"))
         return self._plugins["mocap"]
 
     @property
     def offboard(self) -> Offboard:
         if "offboard" not in self._plugins:
-            raise RuntimeError("Offboard plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Offboard"))
         return self._plugins["offboard"]
 
     @property
     def param(self) -> Param:
         if "param" not in self._plugins:
-            raise RuntimeError("Param plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Param"))
         return self._plugins["param"]
 
     @property
     def shell(self) -> Shell:
         if "shell" not in self._plugins:
-            raise RuntimeError("Shell plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Shell"))
         return self._plugins["shell"]
 
     @property
     def telemetry(self) -> Telemetry:
         if "telemetry" not in self._plugins:
-            raise RuntimeError("Telemetry plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Telemetry"))
         return self._plugins["telemetry"]
 
     @property
     def tune(self) -> Tune:
         if "tune" not in self._plugins:
-            raise RuntimeError("Tune plugin has not been initialized! Did you run `System.connect()`?")
+            raise RuntimeError(self.error_uninitialized("Tune"))
         return self._plugins["tune"]
 
     @staticmethod
@@ -233,7 +238,6 @@ class System:
                        'drone = System(mavsdk_server_address='localhost', port=50051)'
                   """)
             sys.exit(1)
-
 
         def cleanup():
             p.kill()

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -172,7 +172,8 @@ class System:
                                      stdout=subprocess.DEVNULL,
                                      stderr=subprocess.DEVNULL)
         except FileNotFoundError:
-            raise Exception("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n\t1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build from source).\n\t2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n\t3. Set the 'mavsdk_server_address' and port when creating the System:\n\t   'drone = System(mavsdk_server_address='localhost', port=50051)\n")
+            print("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n\t1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build from source).\n\t2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n\t3. Set the 'mavsdk_server_address' and port when creating the System:\n\t   'drone = System(mavsdk_server_address='localhost', port=50051)\n")
+            sys.exit(1)
 
 
         def cleanup():

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -172,7 +172,7 @@ class System:
                                      stdout=subprocess.DEVNULL,
                                      stderr=subprocess.DEVNULL)
         except FileNotFoundError:
-            print("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n  1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build from source).\n  2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n  3. Set the 'mavsdk_server_address' and port when creating the System:\n     'drone = System(mavsdk_server_address='localhost', port=50051)\n")
+            print("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n  1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build it from source).\n  2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n  3. Set the 'mavsdk_server_address' and port when creating the System:\n     'drone = System(mavsdk_server_address='localhost', port=50051)\n")
             sys.exit(1)
 
 

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -12,15 +12,20 @@ class System:
         "Calibration",
         "Camera",
         "Core",
+        "FollowMe",
+        "Ftp",
         "Geofence",
         "Gimbal",
         "Info",
+        "LogFiles",
         "Mission",
+        "MissionRaw",
         "Mocap",
-        "Param",
         "Offboard",
+        "Param",
         "Shell",
-        "Telemetry"
+        "Telemetry",
+        "Tune",
     ]
 
     """Instantiate a System object, that will serve as a proxy to
@@ -94,6 +99,18 @@ class System:
         return self._plugins["core"]
 
     @property
+    def follow_me(self) -> FollowMe:
+        if "follow_me" not in self._plugins:
+            raise RuntimeError("FollowMe plugin has not been initialized! Did you run `System.connect()`?")
+        return self._plugins["follow_me"]
+
+    @property
+    def ftp(self) -> Ftp:
+        if "ftp" not in self._plugins:
+            raise RuntimeError("Ftp plugin has not been initialized! Did you run `System.connect()`?")
+        return self._plugins["Ftp"]
+
+    @property
     def geofence(self) -> Geofence:
         if "geofence" not in self._plugins:
             raise RuntimeError("Geofence plugin has not been initialized! Did you run `System.connect()`?")
@@ -112,16 +129,28 @@ class System:
         return self._plugins["info"]
 
     @property
+    def log_files(self) -> LogFiles:
+        if "log_files" not in self._plugins:
+            raise RuntimeError("LogFiles plugin has not been initialized! Did you run `System.connect()`?")
+        return self._plugins["log_files"]
+
+    @property
     def mission(self) -> Mission:
         if "mission" not in self._plugins:
             raise RuntimeError("Mission plugin has not been initialized! Did you run `System.connect()`?")
         return self._plugins["mission"]
 
     @property
-    def param(self) -> Param:
-        if "param" not in self._plugins:
-            raise RuntimeError("Param plugin has not been initialized! Did you run `System.connect()`?")
-        return self._plugins["param"]
+    def mission_raw(self) -> MissionRaw:
+        if "mission_raw" not in self._plugins:
+            raise RuntimeError("MissionRaw plugin has not been initialized! Did you run `System.connect()`?")
+        return self._plugins["mission_raw"]
+
+    @property
+    def mocap(self) -> Mocap:
+        if "mocap" not in self._plugins:
+            raise RuntimeError("Mocap plugin has not been initialized! Did you run `System.connect()`?")
+        return self._plugins["mocap"]
 
     @property
     def offboard(self) -> Offboard:
@@ -130,10 +159,10 @@ class System:
         return self._plugins["offboard"]
 
     @property
-    def telemetry(self) -> Telemetry:
-        if "telemetry" not in self._plugins:
-            raise RuntimeError("Telemetry plugin has not been initialized! Did you run `System.connect()`?")
-        return self._plugins["telemetry"]
+    def param(self) -> Param:
+        if "param" not in self._plugins:
+            raise RuntimeError("Param plugin has not been initialized! Did you run `System.connect()`?")
+        return self._plugins["param"]
 
     @property
     def shell(self) -> Shell:
@@ -142,10 +171,16 @@ class System:
         return self._plugins["shell"]
 
     @property
-    def mocap(self) -> Mocap:
-        if "mocap" not in self._plugins:
-            raise RuntimeError("Mocap plugin has not been initialized! Did you run `System.connect()`?")
-        return self._plugins["mocap"]
+    def telemetry(self) -> Telemetry:
+        if "telemetry" not in self._plugins:
+            raise RuntimeError("Telemetry plugin has not been initialized! Did you run `System.connect()`?")
+        return self._plugins["telemetry"]
+
+    @property
+    def tune(self) -> Tune:
+        if "tune" not in self._plugins:
+            raise RuntimeError("Tune plugin has not been initialized! Did you run `System.connect()`?")
+        return self._plugins["tune"]
 
     @staticmethod
     def _start_mavsdk_server(system_address=None):

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -172,7 +172,7 @@ class System:
                                      stdout=subprocess.DEVNULL,
                                      stderr=subprocess.DEVNULL)
         except FileNotFoundError:
-            print("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n\t1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build from source).\n\t2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n\t3. Set the 'mavsdk_server_address' and port when creating the System:\n\t   'drone = System(mavsdk_server_address='localhost', port=50051)\n")
+            print("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n  1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build from source).\n  2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n  3. Set the 'mavsdk_server_address' and port when creating the System:\n     'drone = System(mavsdk_server_address='localhost', port=50051)\n")
             sys.exit(1)
 
 

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -230,13 +230,21 @@ class System:
                                      stderr=subprocess.DEVNULL)
         except FileNotFoundError:
             print("""
-                  It seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:
+This installation does not provide an embedded 'mavsdk_server' binary.
+If you installed using pip, this means that 'mavsdk_server' is not distributed
+for your platform yet (e.g. arm).
 
-                    1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build it from source).
-                    2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.
-                    3. Set the 'mavsdk_server_address' and port when creating the System:
-                       'drone = System(mavsdk_server_address='localhost', port=50051)'
-                  """)
+You will need to get and run the 'mavsdk_server' binary manually:
+
+  1. Download 'mavsdk_server' from: https://github.com/mavlink/mavsdk/releases
+     or build it from source.
+
+  2. Run it, e.g. on port 50051:
+     './mavsdk_server -p 50051'
+
+  3. Set the 'mavsdk_server_address' and port when creating the System:
+     'drone = System(mavsdk_server_address='localhost', port=50051)'
+""")
             sys.exit(1)
 
         def cleanup():

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -172,7 +172,14 @@ class System:
                                      stdout=subprocess.DEVNULL,
                                      stderr=subprocess.DEVNULL)
         except FileNotFoundError:
-            print("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n  1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build it from source).\n  2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n  3. Set the 'mavsdk_server_address' and port when creating the System:\n     'drone = System(mavsdk_server_address='localhost', port=50051)'\n")
+            print("""
+                  It seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:
+
+                    1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build it from source).
+                    2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.
+                    3. Set the 'mavsdk_server_address' and port when creating the System:
+                       'drone = System(mavsdk_server_address='localhost', port=50051)'
+                  """)
             sys.exit(1)
 
 

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -1,7 +1,24 @@
 # -*- coding: utf-8 -*-
 
-from .async_plugin_manager import AsyncPluginManager # NOQA
-from .generated import * # NOQA
+from .async_plugin_manager import AsyncPluginManager
+from .generated import Action
+from .generated import Calibration
+from .generated import Camera
+from .generated import Core
+from .generated import FollowMe
+from .generated import Ftp
+from .generated import Geofence
+from .generated import Gimbal
+from .generated import Info
+from .generated import LogFiles
+from .generated import Mission
+from .generated import MissionRaw
+from .generated import Mocap
+from .generated import Offboard
+from .generated import Param
+from .generated import Shell
+from .generated import Telemetry
+from .generated import Tune
 
 from . import bin
 

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -172,7 +172,7 @@ class System:
                                      stdout=subprocess.DEVNULL,
                                      stderr=subprocess.DEVNULL)
         except FileNotFoundError:
-            raise Exception("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n\t1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build from source).\n\t2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n\t3. Set the 'mavsdk_server_address' and port when creating the System: 'drone = System(mavsdk_server_address='localhost', port=50051)\n")
+            raise Exception("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n\t1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build from source).\n\t2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n\t3. Set the 'mavsdk_server_address' and port when creating the System:\n\t   'drone = System(mavsdk_server_address='localhost', port=50051)\n")
 
 
         def cleanup():

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -172,7 +172,7 @@ class System:
                                      stdout=subprocess.DEVNULL,
                                      stderr=subprocess.DEVNULL)
         except FileNotFoundError:
-            print("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n  1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build it from source).\n  2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n  3. Set the 'mavsdk_server_address' and port when creating the System:\n     'drone = System(mavsdk_server_address='localhost', port=50051)\n")
+            print("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n  1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build it from source).\n  2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n  3. Set the 'mavsdk_server_address' and port when creating the System:\n     'drone = System(mavsdk_server_address='localhost', port=50051)'\n")
             sys.exit(1)
 
 

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -172,7 +172,7 @@ class System:
                                      stdout=subprocess.DEVNULL,
                                      stderr=subprocess.DEVNULL)
         except FileNotFoundError:
-            raise Exception("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n\t1. Build 'mavsdk_server': https://github.com/mavlink/mavsdk.\n\t2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n\t3. Set the 'mavsdk_server_address' and port when creating the System: 'drone = System(mavsdk_server_address='localhost', port=50051)\n")
+            raise Exception("\nIt seems like this installation does not provide an embedded 'mavsdk_server' binary. If you installed from pip, it means that 'mavsdk_server' is not distributed for your platform (yet). You will need to get and run it manually:\n\n\t1. Download 'mavsdk_server' from releases: https://github.com/mavlink/mavsdk/releases (or build from source).\n\t2. Run it, e.g. on port 50051: './mavsdk_server -p 50051'.\n\t3. Set the 'mavsdk_server_address' and port when creating the System: 'drone = System(mavsdk_server_address='localhost', port=50051)\n")
 
 
         def cleanup():


### PR DESCRIPTION
Instead of a whole lot of exception output the user is now presented with the text below:

```
pi@rpi3-test:~/src/MAVSDK-Python $ examples/mission.py 

This installation does not provide an embedded 'mavsdk_server' binary.
If you installed using pip, this means that 'mavsdk_server' is not distributed
for your platform yet (e.g. arm).

You will need to get and run the 'mavsdk_server' binary manually:

  1. Download 'mavsdk_server' from: https://github.com/mavlink/mavsdk/releases
     or build it from source.

  2. Run it, e.g. on port 50051:
     './mavsdk_server -p 50051'

  3. Set the 'mavsdk_server_address' and port when creating the System:
     'drone = System(mavsdk_server_address='localhost', port=50051)'

```

Also, the added plugins are added so they can be used.