### PR TITLE
Handle repeated non-primitive types in translate_from_rpc

### DIFF
--- a/mavsdk/generated/camera.py
+++ b/mavsdk/generated/camera.py
@@ -1386,7 +1386,7 @@ class SettingOptions:
                 rpcSettingOptions.setting_description,
                 
                 
-                Option.translate_from_rpc(rpcSettingOptions.options),
+                map(lambda elem: Option.translate_from_rpc(elem), rpcSettingOptions.options),
                 
                 
                 rpcSettingOptions.is_range

--- a/mavsdk/generated/geofence.py
+++ b/mavsdk/generated/geofence.py
@@ -164,7 +164,7 @@ class Polygon:
         """ Translates a gRPC struct to the SDK equivalent """
         return Polygon(
                 
-                Point.translate_from_rpc(rpcPolygon.points),
+                map(lambda elem: Point.translate_from_rpc(elem), rpcPolygon.points),
                 
                 
                 Polygon.Type.translate_from_rpc(rpcPolygon.type)

--- a/mavsdk/generated/mission.py
+++ b/mavsdk/generated/mission.py
@@ -322,7 +322,7 @@ class MissionPlan:
         """ Translates a gRPC struct to the SDK equivalent """
         return MissionPlan(
                 
-                MissionItem.translate_from_rpc(rpcMissionPlan.mission_items)
+                map(lambda elem: MissionItem.translate_from_rpc(elem), rpcMissionPlan.mission_items)
                 )
 
     def translate_to_rpc(self, rpcMissionPlan):

--- a/mavsdk/generated/offboard.py
+++ b/mavsdk/generated/offboard.py
@@ -227,7 +227,7 @@ class ActuatorControl:
         """ Translates a gRPC struct to the SDK equivalent """
         return ActuatorControl(
                 
-                ActuatorControlGroup.translate_from_rpc(rpcActuatorControl.groups)
+                map(lambda elem: ActuatorControlGroup.translate_from_rpc(elem), rpcActuatorControl.groups)
                 )
 
     def translate_to_rpc(self, rpcActuatorControl):

--- a/mavsdk/generated/tune.py
+++ b/mavsdk/generated/tune.py
@@ -242,7 +242,7 @@ class TuneDescription:
         """ Translates a gRPC struct to the SDK equivalent """
         return TuneDescription(
                 
-                SongElement.translate_from_rpc(rpcTuneDescription.song_elements),
+                map(lambda elem: SongElement.translate_from_rpc(elem), rpcTuneDescription.song_elements),
                 
                 
                 rpcTuneDescription.tempo

--- a/other/templates/py/struct.j2
+++ b/other/templates/py/struct.j2
@@ -55,7 +55,11 @@ class {{ name.upper_camel_case }}:
                 {% if field.type_info.is_primitive %}
                 rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}{{ "," if not loop.last }}
                 {% else %}
+                    {%- if field.type_info.is_repeated %}
+                map(lambda elem: {{ field.type_info.inner_name }}.translate_from_rpc(elem), rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}){{ "," if not loop.last }}
+                    {%- else %}
                 {% if field.type_info.parent_type is not none %}{{ field.type_info.parent_type }}.{% endif %}{{ field.type_info.inner_name }}.translate_from_rpc(rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}){{ "," if not loop.last }}
+                    {%- endif %}
                 {% endif %}
                 {%- endfor %})
 


### PR DESCRIPTION
Fixes #201.

@petergerten: would you mind testing this? On my end I can now load your `test.plan`.