### PR TITLE
templates: add note that file is auto-generated

### DIFF
--- a/other/templates/py/file.j2
+++ b/other/templates/py/file.j2
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import {{ plugin_name.lower_snake_case }}_pb2, {{ plugin_name.lower_snake_case }}_pb2_grpc
 from enum import Enum


### PR DESCRIPTION
To prevent things like https://github.com/mavlink/MAVSDK-Python/pull/213 in the future.