### PR TITLE
Added functionality to allow for mavsdk server port to be specified

### DIFF
--- a/mavsdk/action.py
+++ b/mavsdk/action.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import action_pb2, action_pb2_grpc
 from enum import Enum

--- a/mavsdk/calibration.py
+++ b/mavsdk/calibration.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import calibration_pb2, calibration_pb2_grpc
 from enum import Enum

--- a/mavsdk/camera.py
+++ b/mavsdk/camera.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import camera_pb2, camera_pb2_grpc
 from enum import Enum

--- a/mavsdk/core.py
+++ b/mavsdk/core.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import core_pb2, core_pb2_grpc
 from enum import Enum

--- a/mavsdk/follow_me.py
+++ b/mavsdk/follow_me.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import follow_me_pb2, follow_me_pb2_grpc
 from enum import Enum

--- a/mavsdk/ftp.py
+++ b/mavsdk/ftp.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import ftp_pb2, ftp_pb2_grpc
 from enum import Enum

--- a/mavsdk/geofence.py
+++ b/mavsdk/geofence.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import geofence_pb2, geofence_pb2_grpc
 from enum import Enum

--- a/mavsdk/gimbal.py
+++ b/mavsdk/gimbal.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import gimbal_pb2, gimbal_pb2_grpc
 from enum import Enum

--- a/mavsdk/info.py
+++ b/mavsdk/info.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import info_pb2, info_pb2_grpc
 from enum import Enum

--- a/mavsdk/log_files.py
+++ b/mavsdk/log_files.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import log_files_pb2, log_files_pb2_grpc
 from enum import Enum

--- a/mavsdk/mission.py
+++ b/mavsdk/mission.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import mission_pb2, mission_pb2_grpc
 from enum import Enum

--- a/mavsdk/mission_raw.py
+++ b/mavsdk/mission_raw.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import mission_raw_pb2, mission_raw_pb2_grpc
 from enum import Enum

--- a/mavsdk/mocap.py
+++ b/mavsdk/mocap.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import mocap_pb2, mocap_pb2_grpc
 from enum import Enum

--- a/mavsdk/offboard.py
+++ b/mavsdk/offboard.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import offboard_pb2, offboard_pb2_grpc
 from enum import Enum

--- a/mavsdk/param.py
+++ b/mavsdk/param.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import param_pb2, param_pb2_grpc
 from enum import Enum

--- a/mavsdk/shell.py
+++ b/mavsdk/shell.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import shell_pb2, shell_pb2_grpc
 from enum import Enum

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -64,7 +64,7 @@ class System:
         """
         if self._mavsdk_server_address is None:
             self._mavsdk_server_address = 'localhost'
-            self._start_mavsdk_server(system_address)
+            self._start_mavsdk_server(system_address,self._port)
 
         await self._init_plugins(self._mavsdk_server_address, self._port)
 
@@ -205,9 +205,10 @@ class System:
         return self._plugins["tune"]
 
     @staticmethod
-    def _start_mavsdk_server(system_address=None):
+    def _start_mavsdk_server(system_address=None,port=50051):
         """
-        Starts the gRPC server in a subprocess, listening on localhost:50051
+        Starts the gRPC server in a subprocess, listening on localhost:port
+        port parameter can be specified now to allow multiple mavsdk servers to be spawned via code
         """
         import atexit
         import os
@@ -221,7 +222,7 @@ class System:
 
         try:
             with path(bin, 'mavsdk_server') as backend:
-                bin_path_and_args = [os.fspath(backend), "-p", "50051"]
+                bin_path_and_args = [os.fspath(backend), "-p", str(port)]
                 if system_address:
                     bin_path_and_args.append(system_address)
                 p = subprocess.Popen(bin_path_and_args,

--- a/mavsdk/telemetry.py
+++ b/mavsdk/telemetry.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import telemetry_pb2, telemetry_pb2_grpc
 from enum import Enum

--- a/mavsdk/tune.py
+++ b/mavsdk/tune.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+# DO NOT EDIT! This file is auto-generated from
+# https://github.com/mavlink/MAVSDK-Python/tree/master/other/templates/py
 from ._base import AsyncBase
 from . import tune_pb2, tune_pb2_grpc
 from enum import Enum


### PR DESCRIPTION
When trying to create a wrapper [(MAVFleetControl)](https://github.com/julianblanco/MAVFleetControl) for mavsdk-python to control multiple aircraft, ran into an issue that the port for mavsdk server was hardcoded. Made changes allowing the user to specify the port and ensured default was the hard coded port (to hopefully not break other peoples code)
