### PR TITLE
examples: closer goto, and go up, not down

### DIFF
--- a/examples/goto.py
+++ b/examples/goto.py
@@ -28,7 +28,10 @@ async def run():
 
     await asyncio.sleep(1)
 
-    await drone.action.goto_location(55.8688660, -4.2851267, 40, 0)
+    await drone.action.goto_location(47.399386, 8.535245, 500, 0)
+
+    while True:
+        await asyncio.sleep(1)
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()

--- a/examples/goto.py
+++ b/examples/goto.py
@@ -28,10 +28,7 @@ async def run():
 
     await asyncio.sleep(1)
 
-    await drone.action.goto_location(47.399386, 8.535245, 500, 0)
-
-    while True:
-        await asyncio.sleep(1)
+    await drone.action.goto_location(47.399386, 8.535245, 500, float('nan'))
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
This is required because the goto altitude is absolute.