### PR TITLE
fix protobuf version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-protobuf>=3.5.1
+protobuf>=3.13.0
 aiogrpc>=1.5
 grpcio>=1.11.0
 importlib_resources>=1.0.2;python_version<"3.7"


### PR DESCRIPTION
I had protobuf 3.11.3 which gave me this error when importing mavsdk:
AttributeError: module 'google.protobuf.descriptor' has no attribute '_internal_create_key'

It is ok after updating protobuf to 3.13.0.