### PR TITLE
Twine fix for Win and aarch64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,8 +62,11 @@ jobs:
       matrix:
         include:
           - arch: armv6l
+            pypi_arch: linux_armv6l
           - arch: armv7l
+            pypi_arch: linux_armv7l
           - arch: aarch64
+            pypi_arch: manylinux2014_aarch64
 
     steps:
       - uses: actions/checkout@v1
@@ -88,7 +91,7 @@ jobs:
         run: |
           export MAVSDK_SERVER_ARCH=${{ matrix.arch }}
           python3 setup.py bdist_wheel
-          ls dist/*any.whl | sed -e 'p;s/any/linux_${{ matrix.arch }}/' | xargs -n2 mv
+          ls dist/*any.whl | sed -e 'p;s/any/${{ matrix.pypi_arch }}/' | xargs -n2 mv
 
       - name: Check the artifacts
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -196,5 +196,4 @@ jobs:
           TWINE_NON_INTERACTIVE: 1
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          export PATH=$PATH:$HOME/.local/bin
           twine upload dist/*.whl


### PR DESCRIPTION
Turns out `linux_aarch64` is not ok.