### PR TITLE
Convert (lazy) maps to lists

### DIFF
--- a/mavsdk/camera.py
+++ b/mavsdk/camera.py
@@ -1388,7 +1388,7 @@ class SettingOptions:
                 rpcSettingOptions.setting_description,
                 
                 
-                map(lambda elem: Option.translate_from_rpc(elem), rpcSettingOptions.options),
+                list(map(lambda elem: Option.translate_from_rpc(elem), rpcSettingOptions.options)),
                 
                 
                 rpcSettingOptions.is_range

--- a/mavsdk/geofence.py
+++ b/mavsdk/geofence.py
@@ -166,7 +166,7 @@ class Polygon:
         """ Translates a gRPC struct to the SDK equivalent """
         return Polygon(
                 
-                map(lambda elem: Point.translate_from_rpc(elem), rpcPolygon.points),
+                list(map(lambda elem: Point.translate_from_rpc(elem), rpcPolygon.points)),
                 
                 
                 Polygon.FenceType.translate_from_rpc(rpcPolygon.fence_type)

--- a/mavsdk/mission.py
+++ b/mavsdk/mission.py
@@ -324,7 +324,7 @@ class MissionPlan:
         """ Translates a gRPC struct to the SDK equivalent """
         return MissionPlan(
                 
-                map(lambda elem: MissionItem.translate_from_rpc(elem), rpcMissionPlan.mission_items)
+                list(map(lambda elem: MissionItem.translate_from_rpc(elem), rpcMissionPlan.mission_items))
                 )
 
     def translate_to_rpc(self, rpcMissionPlan):

--- a/mavsdk/offboard.py
+++ b/mavsdk/offboard.py
@@ -229,7 +229,7 @@ class ActuatorControl:
         """ Translates a gRPC struct to the SDK equivalent """
         return ActuatorControl(
                 
-                map(lambda elem: ActuatorControlGroup.translate_from_rpc(elem), rpcActuatorControl.groups)
+                list(map(lambda elem: ActuatorControlGroup.translate_from_rpc(elem), rpcActuatorControl.groups))
                 )
 
     def translate_to_rpc(self, rpcActuatorControl):

--- a/mavsdk/param.py
+++ b/mavsdk/param.py
@@ -204,10 +204,10 @@ class AllParams:
         """ Translates a gRPC struct to the SDK equivalent """
         return AllParams(
                 
-                map(lambda elem: IntParam.translate_from_rpc(elem), rpcAllParams.int_params),
+                list(map(lambda elem: IntParam.translate_from_rpc(elem), rpcAllParams.int_params)),
                 
                 
-                map(lambda elem: FloatParam.translate_from_rpc(elem), rpcAllParams.float_params)
+                list(map(lambda elem: FloatParam.translate_from_rpc(elem), rpcAllParams.float_params))
                 )
 
     def translate_to_rpc(self, rpcAllParams):

--- a/mavsdk/tune.py
+++ b/mavsdk/tune.py
@@ -244,7 +244,7 @@ class TuneDescription:
         """ Translates a gRPC struct to the SDK equivalent """
         return TuneDescription(
                 
-                map(lambda elem: SongElement.translate_from_rpc(elem), rpcTuneDescription.song_elements),
+                list(map(lambda elem: SongElement.translate_from_rpc(elem), rpcTuneDescription.song_elements)),
                 
                 
                 rpcTuneDescription.tempo

--- a/other/templates/py/struct.j2
+++ b/other/templates/py/struct.j2
@@ -56,7 +56,7 @@ class {{ name.upper_camel_case }}:
                 rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}{{ "," if not loop.last }}
                 {% else %}
                     {%- if field.type_info.is_repeated %}
-                map(lambda elem: {{ field.type_info.inner_name }}.translate_from_rpc(elem), rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}){{ "," if not loop.last }}
+                list(map(lambda elem: {{ field.type_info.inner_name }}.translate_from_rpc(elem), rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }})){{ "," if not loop.last }}
                     {%- else %}
                 {% if field.type_info.parent_type is not none %}{{ field.type_info.parent_type }}.{% endif %}{{ field.type_info.inner_name }}.translate_from_rpc(rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}){{ "," if not loop.last }}
                     {%- endif %}


### PR DESCRIPTION
Maps are lazy-evaluated. We want lists in this case, so they need to be converted.