### PR TITLE
add a System destructor to kill mavsdk_server when an instance is removed

### DIFF
--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -49,6 +49,9 @@ class System:
         self._plugins = {}
         self._server_process = None
 
+    def __del__(self):
+        self._stop_mavsdk_server()
+
     async def connect(self, system_address=None):
         """
         Connect the System object to a remote system.


### PR DESCRIPTION
I forgot to add this commit to my previous merge request.

It allow to automatically close mavsdk_server when launch by a mavsdk-python instance that is deleted
