### PR TITLE
Update protoc-gen-mavsdk requirement

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 grpcio-tools>=1.11.0
-protoc-gen-mavsdk>=1.0.0
+protoc-gen-mavsdk>=1.0.1


### PR DESCRIPTION
Note: to be merged after 1.0.1 is actually deployed (see [here](https://github.com/mavlink/MAVSDK-Proto/pull/210))