### PR TITLE
follow_me_example: also check home position

### DIFF
--- a/examples/follow_me_example.py
+++ b/examples/follow_me_example.py
@@ -28,7 +28,7 @@ async def fly_drone():
 
     #Checking if Global Position Estimate is ok
     async for global_lock in drone.telemetry.health():
-        if global_lock.is_global_position_ok:
+        if global_lock.is_global_position_ok and global_lock.is_home_position_ok:
             print("-- Global position state is good enough for flying.")
             break
 


### PR DESCRIPTION
Some versions of PX4 fail with this example because GPS checks are passed before a home position is set. The example code tries to arm without home position then, which is rejected.

Here is the nuttx shell output for the original code
```
INFO  [ecl/EKF] 2568000: EKF aligned, (baro hgt, IMU buf: 18, OBS buf: 14)
INFO  [ecl/EKF] 2568000: reset position to last known position
INFO  [ecl/EKF] 2568000: reset velocity to zero
INFO  [ecl/EKF] 9876000: GPS checks passed                                   <----- GPS check passing
INFO  [commander] Armed by external command                               <----- armed by mavsdk
WARN  [commander] Failsafe enabled: No manual control stick input
INFO  [commander] Failsafe mode activated
WARN  [commander] Takeoff denied! Please disarm and retry
INFO  [ecl/EKF] 14368000: reset position to GPS                                <----- home position set
INFO  [ecl/EKF] 14368000: reset velocity to GPS
INFO  [ecl/EKF] 14368000: starting GPS fusion
```

and here's the output with the fix
```
INFO  [ecl/EKF] 2568000: EKF aligned, (baro hgt, IMU buf: 18, OBS buf: 14)
INFO  [ecl/EKF] 2568000: reset position to last known position
INFO  [ecl/EKF] 2568000: reset velocity to zero
INFO  [ecl/EKF] 9880000: GPS checks passed                                   <----- GPS check passing
INFO  [ecl/EKF] 14368000: reset position to GPS                                <----- home position set
INFO  [ecl/EKF] 14368000: reset velocity to GPS
INFO  [ecl/EKF] 14368000: starting GPS fusion
INFO  [commander] Armed by external command                                <----- armed by mavsdk
INFO  [navigator] Using minimum takeoff altitude: 1.50 m
INFO  [commander] Takeoff detected
```