### PR TITLE
Replace print statements with logging statements

### DIFF
--- a/mavsdk/async_plugin_manager.py
+++ b/mavsdk/async_plugin_manager.py
@@ -2,8 +2,6 @@
 import logging
 import aiogrpc
 
-_logger = logging.getLogger(__name__)
-
 
 class AsyncPluginManager:
     """
@@ -32,9 +30,13 @@ class AsyncPluginManager:
             "{}:{}".format(self.host, self.port)
         )
 
-        _logger.debug("Waiting for mavsdk_server to be ready...")
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.DEBUG)  # Enable debug messages by default
+        logger.addHandler(logging.NullHandler())  # Avoid errors when user has not configured logging
+
+        logger.debug("Waiting for mavsdk_server to be ready...")
         await aiogrpc.channel_ready_future(self._channel)
-        _logger.debug("Connected to mavsdk_server!")
+        logger.debug("Connected to mavsdk_server!")
 
     @property
     def channel(self):

--- a/mavsdk/async_plugin_manager.py
+++ b/mavsdk/async_plugin_manager.py
@@ -31,7 +31,6 @@ class AsyncPluginManager:
         )
 
         logger = logging.getLogger(__name__)
-        logger.setLevel(logging.DEBUG)  # Enable debug messages by default
         logger.addHandler(logging.NullHandler())  # Avoid errors when user has not configured logging
 
         logger.debug("Waiting for mavsdk_server to be ready...")

--- a/mavsdk/async_plugin_manager.py
+++ b/mavsdk/async_plugin_manager.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+import logging
 import aiogrpc
+
+_logger = logging.getLogger(__name__)
 
 
 class AsyncPluginManager:
@@ -29,9 +32,9 @@ class AsyncPluginManager:
             "{}:{}".format(self.host, self.port)
         )
 
-        print("Waiting for mavsdk_server to be ready...")
+        _logger.debug("Waiting for mavsdk_server to be ready...")
         await aiogrpc.channel_ready_future(self._channel)
-        print("Connected to mavsdk_server!")
+        _logger.debug("Connected to mavsdk_server!")
 
     @property
     def channel(self):

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import logging
+import threading
+
 from .async_plugin_manager import AsyncPluginManager
 
 from . import action
@@ -27,6 +30,16 @@ from . import tune
 
 from . import bin
 
+
+class _LoggingThread(threading.Thread):
+    def __init__(self, pipe, log_fn):
+        super().__init__()
+        self.pipe = pipe
+        self.log_fn = log_fn
+
+    def run(self):
+        for line in self.pipe:
+            self.log_fn(line.decode("utf-8").replace("\n", ""))
 
 class System:
     """
@@ -281,8 +294,12 @@ class System:
                     bin_path_and_args.append(system_address)
                 p = subprocess.Popen(bin_path_and_args,
                                      shell=False,
-                                     stdout=subprocess.DEVNULL,
-                                     stderr=subprocess.DEVNULL)
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.STDOUT)
+
+                logger = logging.getLogger(__name__)
+                log_thread = _LoggingThread(p.stdout, logger.debug)
+                log_thread.start()
         except FileNotFoundError:
             print("""
 This installation does not provide an embedded 'mavsdk_server' binary.


### PR DESCRIPTION
The print statements in the `async_plugin_manager` module can create visual clutter when connecting to multiple systems. Users should be able to decide if those statements are printed by configuring logging on an application level.

By default, if logging is configured the mavsdk connection messages should be printed. Users can easily silence them by selecting the appropriate logger and setting the level to anything above DEBUG.

Example:

```python
logging.getLogger("mavsdk.async_plugin_manager").setLevel(logging.INFO)
```