### PR TITLE
macOS support for run_protoc.sh

### DIFF
--- a/other/tools/run_protoc.sh
+++ b/other/tools/run_protoc.sh
@@ -24,7 +24,11 @@ command -v protoc-gen-mavsdk > /dev/null || {
 }
 
 function snake_case_to_camel_case {
-    echo $1 | sed -r 's/(^|_)([a-z])/\U\2/g'
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo $1 | gsed -r 's/(^|_)([a-z])/\U\2/g'
+    else
+        echo $1 | sed -r 's/(^|_)([a-z])/\U\2/g'
+    fi
 }
 
 function generate {

--- a/other/tools/run_protoc.sh
+++ b/other/tools/run_protoc.sh
@@ -24,11 +24,7 @@ command -v protoc-gen-mavsdk > /dev/null || {
 }
 
 function snake_case_to_camel_case {
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        echo $1 | gsed -r 's/(^|_)([a-z])/\U\2/g'
-    else
-        echo $1 | sed -r 's/(^|_)([a-z])/\U\2/g'
-    fi
+    echo $1 | awk -v FS="_" -v OFS="" '{for (i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) substr($i,2)} 1'
 }
 
 function generate {


### PR DESCRIPTION
I stumbled over an incompatibility with the macOS version of sed. I got this solved by doing this little hack using the homebrew gnu-sed package. There might be better solutions but I am neither a bash nor an regex expert but I think I'd better come with a solution than a problem. 😄 