### PR TITLE
Use `!=` instead of `is not` for values.

### DIFF
--- a/examples/telemetry_takeoff_and_land.py
+++ b/examples/telemetry_takeoff_and_land.py
@@ -75,7 +75,7 @@ async def print_flight_mode(drone):
     previous_flight_mode = None
 
     async for flight_mode in drone.telemetry.flight_mode():
-        if flight_mode is not previous_flight_mode:
+        if flight_mode != previous_flight_mode:
             previous_flight_mode = flight_mode
             print(f"Flight mode: {flight_mode}")
 

--- a/other/templates/py/call.j2
+++ b/other/templates/py/call.j2
@@ -48,6 +48,6 @@ async def {{ name.lower_snake_case }}(self{% for param in params %}, {{ param.na
     {% if has_result %}
     result = self._extract_result(response)
 
-    if result.result is not {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
+    if result.result != {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
         raise {{ plugin_name.upper_camel_case }}Error(result, "{{ name.lower_snake_case }}()"{% for param in params %}, {{ param.name.lower_snake_case }}{% endfor %})
     {% endif %}

--- a/other/templates/py/request.j2
+++ b/other/templates/py/request.j2
@@ -52,7 +52,7 @@ async def {{ name.lower_snake_case }}(self{% for param in params %}, {{ param.na
     {% if has_result %}
     result = self._extract_result(response)
 
-    if result.result is not {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
+    if result.result != {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
         raise {{ plugin_name.upper_camel_case }}Error(result, "{{ name.lower_snake_case }}()"{% for param in params %}, {{ param.name.lower_snake_case }}{% endfor %})
     {% endif %}
 

--- a/other/templates/py/stream.j2
+++ b/other/templates/py/stream.j2
@@ -61,7 +61,7 @@ async def {{ name.lower_snake_case }}(self{% for param in params %}, {{ param.na
             if result.result not in success_codes:
                 raise {{ plugin_name.upper_camel_case }}Error(result, "{{ name.lower_snake_case }}()"{% for param in params %}, {{ param.name.lower_snake_case }}{% endfor %})
 
-            if result.result is {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
+            if result.result == {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
                 {{ name.lower_snake_case }}_stream.cancel();
                 return
             {% endif %}


### PR DESCRIPTION
This uses the `==`/`!=` operators instead of `is`/`is not` when checking the return value of RPC calls. In Python, `is not` tests if the  two operands are the same object whereas `!=` test that they have the same value. `is not` just happens to work for small integers due to an implementation detail in CPython (e.g. see [StackOverflow][1]).

[1]: https://stackoverflow.com/a/133024/1976323