### PR TITLE
Create a new thread pool for each streaming method of gRPC channel

### DIFF
--- a/mavsdk/async_plugin_manager.py
+++ b/mavsdk/async_plugin_manager.py
@@ -27,7 +27,8 @@ class AsyncPluginManager:
 
         #: gRPC channel
         self._channel = aiogrpc.insecure_channel(
-            "{}:{}".format(self.host, self.port)
+            "{}:{}".format(self.host, self.port),
+            standalone_pool_for_streaming=True
         )
 
         logger = logging.getLogger(__name__)


### PR DESCRIPTION
Create one separate thread pool (with 1 thread) for each streaming method.

It fixes issue of limited number of threads processing incoming streams. This problem led to situation, when subscriptions, waiting for stream response, did not let other subscriptions receive responses, that were already send by server.

Resolves #380 