### PR TITLE
Add mavshell example

### DIFF
--- a/examples/shell.py
+++ b/examples/shell.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import asyncio
+import sys
+
+from mavsdk import System
+
+
+async def run():
+    drone = System()
+    await drone.connect(system_address="udp://:14540")
+
+    asyncio.ensure_future(observe_shell(drone))
+
+    print("Waiting for drone to connect...")
+    async for state in drone.core.connection_state():
+        if state.is_connected:
+            print(f"Drone discovered!")
+            break
+
+    asyncio.get_event_loop().add_reader(sys.stdin, got_stdin_data, drone)
+    print("nsh> ", end='', flush=True)
+
+async def observe_shell(drone):
+    async for output in drone.shell.receive():
+        print(f"\n{output} ", end='', flush=True)
+
+def got_stdin_data(drone):
+    asyncio.ensure_future(send(drone, sys.stdin.readline()))
+
+async def send(drone, command):
+    await drone.shell.send(command)
+
+
+if __name__ == "__main__":
+    asyncio.ensure_future(run())
+
+    try:
+        asyncio.get_event_loop().run_forever()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
To test (against a real board, SITL won't work):

1. Create a venv (or don't, but that's what I do):
    ```
    mkdir /tmp/test_mavshell && cd /tmp/test_mavshell
    python -m venv venv
    source ./venv/bin/activate
    ```
2. Install mavsdk (if not in a venv, use `pip install --user mavsdk` instead):
    ```
    pip install mavsdk
    ```
3. Run the example:
    ```
    python shell.py
    ```

Note: This assumes that you receive MAVLink on udp port 14540. If not, change the `await drone.connect(system_address="udp://:14540")` to listen to whatever you have (maybe `serial:///dev/ttyACM0`, maybe `udp://:14550`, you name it)