### PR TITLE
Fix for MissionItem class to incorporate camera_photo_distance_m param

### DIFF
--- a/examples/mission.py
+++ b/examples/mission.py
@@ -35,6 +35,7 @@ async def run():
                                      float('nan'),
                                      float('nan'),
                                      float('nan'),
+                                     float('nan'),
                                      float('nan')))
     mission_items.append(MissionItem(47.398036222362471,
                                      8.5450146439425509,
@@ -47,6 +48,7 @@ async def run():
                                      float('nan'),
                                      float('nan'),
                                      float('nan'),
+                                     float('nan'),
                                      float('nan')))
     mission_items.append(MissionItem(47.397825620791885,
                                      8.5450092830163271,
@@ -56,6 +58,7 @@ async def run():
                                      float('nan'),
                                      float('nan'),
                                      MissionItem.CameraAction.NONE,
+                                     float('nan'),
                                      float('nan'),
                                      float('nan'),
                                      float('nan'),


### PR DESCRIPTION
Prior to this change I was receiving the following error message:

TypeError: __init__() missing 1 required positional argument: 'camera_photo_distance_m'

After adding the default argument it runs well.