### PR TITLE
Same connection and GPS checks in all examples

### DIFF
--- a/examples/camera.py
+++ b/examples/camera.py
@@ -13,7 +13,7 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     print_mode_task = asyncio.ensure_future(print_mode(drone))

--- a/examples/failure_injection.py
+++ b/examples/failure_injection.py
@@ -12,13 +12,13 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered with UUID: {state.uuid}")
+            print(f"-- Connected to drone!")
             break
 
     print("Waiting for drone to have a global position estimate...")
     async for health in drone.telemetry.health():
         if health.is_global_position_ok and health.is_home_position_ok:
-            print("Global position estimate ok")
+            print("-- Global position estimate OK")
             break
 
     print("-- Enabling failure injection")

--- a/examples/firmware_version.py
+++ b/examples/firmware_version.py
@@ -11,7 +11,7 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     info = await drone.info.get_version()

--- a/examples/follow_me_example.py
+++ b/examples/follow_me_example.py
@@ -20,16 +20,16 @@ async def fly_drone():
     drone = System()
     await drone.connect(system_address="udp://:14540")
 
-    #This waits till a mavlink based drone is connected
+    print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
             print(f"-- Connected to drone!")
             break
 
-    #Checking if Global Position Estimate is ok
-    async for global_lock in drone.telemetry.health():
-        if global_lock.is_global_position_ok and global_lock.is_home_position_ok:
-            print("-- Global position state is good enough for flying.")
+    print("Waiting for drone to have a global position estimate...")
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position estimate OK")
             break
 
     #Arming the drone

--- a/examples/geofence.py
+++ b/examples/geofence.py
@@ -19,10 +19,10 @@ async def run():
     await drone.connect(system_address="udp://:14540")
 
     # Wait for the drone to connect
-    print("Waiting for drone...")
+    print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     # Fetch the home location coordinates, in order to set a boundary around the home location

--- a/examples/goto.py
+++ b/examples/goto.py
@@ -11,13 +11,13 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print("Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     print("Waiting for drone to have a global position estimate...")
     async for health in drone.telemetry.health():
-        if health.is_global_position_ok:
-            print("Global position estimate ok")
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position state is good enough for flying.")
             break
 
     print("Fetching amsl altitude at home location....")

--- a/examples/logfile_download.py
+++ b/examples/logfile_download.py
@@ -12,7 +12,7 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered")
+            print(f"-- Connected to drone!")
             break
 
     entries = await get_entries(drone)

--- a/examples/manual_control.py
+++ b/examples/manual_control.py
@@ -35,15 +35,16 @@ async def manual_controls():
     await drone.connect(system_address="udp://:14540")
 
     # This waits till a mavlink based drone is connected
+    print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
             print(f"-- Connected to drone!")
             break
 
     # Checking if Global Position Estimate is ok
-    async for global_lock in drone.telemetry.health():
-        if global_lock.is_global_position_ok:
-            print("-- Global position state is ok")
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position state is good enough for flying.")
             break
 
     # set the manual control input after arming

--- a/examples/mission.py
+++ b/examples/mission.py
@@ -13,7 +13,7 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print("Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     print_mission_progress_task = asyncio.ensure_future(
@@ -70,6 +70,12 @@ async def run():
 
     print("-- Uploading mission")
     await drone.mission.upload_mission(mission_plan)
+
+    print("Waiting for drone to have a global position estimate...")
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position estimate OK")
+            break
 
     print("-- Arming")
     await drone.action.arm()

--- a/examples/mission_import.py
+++ b/examples/mission_import.py
@@ -13,7 +13,7 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print("Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     mission_import_data = await drone.mission_raw.import_qgroundcontrol_mission("example-mission.plan")

--- a/examples/offboard_attitude.py
+++ b/examples/offboard_attitude.py
@@ -20,7 +20,13 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
+            break
+
+    print("Waiting for drone to have a global position estimate...")
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position estimate OK")
             break
 
     print("-- Arming")

--- a/examples/offboard_position_ned.py
+++ b/examples/offboard_position_ned.py
@@ -20,6 +20,18 @@ async def run():
     drone = System()
     await drone.connect(system_address="udp://:14540")
 
+    print("Waiting for drone to connect...")
+    async for state in drone.core.connection_state():
+        if state.is_connected:
+            print(f"-- Connected to drone!")
+            break
+
+    print("Waiting for drone to have a global position estimate...")
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position estimate OK")
+            break
+
     print("-- Arming")
     await drone.action.arm()
 

--- a/examples/offboard_position_velocity_ned.py
+++ b/examples/offboard_position_velocity_ned.py
@@ -12,7 +12,13 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered with UUID: {state.uuid}")
+            print(f"-- Connected to drone!")
+            break
+
+    print("Waiting for drone to have a global position estimate...")
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position estimate OK")
             break
 
     print("-- Arming")

--- a/examples/offboard_velocity_body.py
+++ b/examples/offboard_velocity_body.py
@@ -16,7 +16,13 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
+            break
+
+    print("Waiting for drone to have a global position estimate...")
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position estimate OK")
             break
 
     print("-- Arming")

--- a/examples/offboard_velocity_ned.py
+++ b/examples/offboard_velocity_ned.py
@@ -16,7 +16,13 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
+            break
+
+    print("Waiting for drone to have a global position estimate...")
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position estimate OK")
             break
 
     print("-- Arming")

--- a/examples/shell.py
+++ b/examples/shell.py
@@ -15,7 +15,7 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     asyncio.get_event_loop().add_reader(sys.stdin, got_stdin_data, drone)

--- a/examples/takeoff_and_land.py
+++ b/examples/takeoff_and_land.py
@@ -12,13 +12,13 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     print("Waiting for drone to have a global position estimate...")
     async for health in drone.telemetry.health():
-        if health.is_global_position_ok:
-            print("Global position estimate ok")
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position estimate OK")
             break
 
     print("-- Arming")

--- a/examples/takeoff_and_land_keyboard_control.py
+++ b/examples/takeoff_and_land_keyboard_control.py
@@ -24,13 +24,13 @@ async def setup():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     print("Waiting for drone to have a global position estimate...")
     async for health in drone.telemetry.health():
-        if health.is_global_position_ok:
-            print("Global position estimate ok")
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position estimate OK")
             break
 
 

--- a/examples/telemetry_flight_mode.py
+++ b/examples/telemetry_flight_mode.py
@@ -11,7 +11,7 @@ async def print_flight_mode():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     async for flight_mode in drone.telemetry.flight_mode():

--- a/examples/telemetry_takeoff_and_land.py
+++ b/examples/telemetry_takeoff_and_land.py
@@ -31,7 +31,7 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     # Start parallel tasks
@@ -40,6 +40,11 @@ async def run():
 
     running_tasks = [print_altitude_task, print_flight_mode_task]
     termination_task = asyncio.ensure_future(observe_is_in_air(drone, running_tasks))
+
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok and health.is_home_position_ok:
+            print("-- Global position state is good enough for flying.")
+            break
 
     # Execute the maneuvers
     print("-- Arming")

--- a/examples/tune.py
+++ b/examples/tune.py
@@ -13,7 +13,7 @@ async def run():
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
-            print(f"Drone discovered!")
+            print(f"-- Connected to drone!")
             break
 
     song_elements = []


### PR DESCRIPTION
Context: https://github.com/mavlink/MAVSDK-Python/issues/369#issuecomment-1073729797

A year ago I extended the check prior to arming from 
```
if health.is_global_position_ok
```
to 
```
if health.is_global_position_ok and health.is_home_position_ok:
```
because otherwise the PX4 preflight checks might fail if the python scripts are too quickly attempting to arm the drone after it acquired GPS.

Unfortunately I added this patch to only a few examples and not all of them. This PR is making up for that, and it also unifies the connection check at the beginning of almost every script. I don't mind the exact phrasing of the messages and whether it's "drone discovered" or "drone connected", but I think it's good to have it similar in all example scripts.