### PR TITLE
Increase takeoff altitude and sleep

### DIFF
--- a/examples/telemetry_takeoff_and_land.py
+++ b/examples/telemetry_takeoff_and_land.py
@@ -46,6 +46,10 @@ async def run():
             print("-- Global position state is good enough for flying.")
             break
 
+    # Take the drone little bit higher during takeoff
+    print("-- Setting takeoff altitude")
+    await drone.param.set_param_float('MIS_TAKEOFF_ALT', 10.0)
+
     # Execute the maneuvers
     print("-- Arming")
     await drone.action.arm()
@@ -53,7 +57,7 @@ async def run():
     print("-- Taking off")
     await drone.action.takeoff()
 
-    await asyncio.sleep(5)
+    await asyncio.sleep(10)
 
     print("-- Landing")
     await drone.action.land()

--- a/examples/telemetry_takeoff_and_land.py
+++ b/examples/telemetry_takeoff_and_land.py
@@ -46,15 +46,12 @@ async def run():
             print("-- Global position state is good enough for flying.")
             break
 
-    # Take the drone little bit higher during takeoff
-    print("-- Setting takeoff altitude")
-    await drone.param.set_param_float('MIS_TAKEOFF_ALT', 10.0)
-
     # Execute the maneuvers
     print("-- Arming")
     await drone.action.arm()
 
     print("-- Taking off")
+    await drone.action.set_takeoff_altitude(10.0)
     await drone.action.takeoff()
 
     await asyncio.sleep(10)


### PR DESCRIPTION
To make the example for `telemetry_takeoff_and_land` more representative  I propose to increase `MIS_TAKEOFF_ALT` parameter and sleep after taking off. 

```
Waiting for drone to connect...
-- Connected to drone!
Altitude: 0
Flight mode: LAND
-- Global position state is good enough for flying.
-- Setting takeoff altitude
-- Arming
-- Taking off
Flight mode: TAKEOFF
Altitude: 1
Altitude: 2
Altitude: 3
Altitude: 4
Altitude: 5
Altitude: 6
Altitude: 7
Altitude: 8
-- Landing
Flight mode: LAND
Altitude: 7
Altitude: 6
Altitude: 5
Altitude: 4
Altitude: 3
Altitude: 2
Altitude: 1
Altitude: 0
Altitude: -1
```

**UPD:**
Action has been used to increase takeoff altitude.