### PR TITLE
takeoff_and_land: print statustext

### DIFF
--- a/examples/takeoff_and_land.py
+++ b/examples/takeoff_and_land.py
@@ -9,6 +9,8 @@ async def run():
     drone = System()
     await drone.connect(system_address="udp://:14540")
 
+    status_text_task = asyncio.ensure_future(print_status_text(drone))
+
     print("Waiting for drone to connect...")
     async for state in drone.core.connection_state():
         if state.is_connected:
@@ -31,6 +33,18 @@ async def run():
 
     print("-- Landing")
     await drone.action.land()
+
+    status_text_task.cancel()
+
+
+
+async def print_status_text(drone):
+    try:
+        async for status_text in drone.telemetry.status_text():
+            print(f"Status: {status_text.type}: {status_text.text}")
+    except asyncio.CancelledError:
+        return
+
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
We get many questions about why arming or takeoff fails with denied. One way to help a user would be to print the status text.