### PR TITLE
update protobuf version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-protobuf>=3.13.0
+protobuf>=3.20.1
 aiogrpc>=1.5
 grpcio>=1.11.0
 importlib_resources>=1.0.2;python_version<"3.7"


### PR DESCRIPTION
google.protobuf.descriptor_pool don't have `enum_types_by_name` field in version 3.13.0

When importing mavsdk, I get: 
```
  File "C:\Users\fclav\anaconda3\lib\site-packages\mavsdk\__init__.py", line 7, in <module>
    from .system import System
  File "C:\Users\fclav\anaconda3\lib\site-packages\mavsdk\system.py", line 8, in <module>
    from . import action
  File "C:\Users\fclav\anaconda3\lib\site-packages\mavsdk\action.py", line 5, in <module>
    from . import action_pb2, action_pb2_grpc
  File "C:\Users\fclav\anaconda3\lib\site-packages\mavsdk\action_pb2.py", line 16, in <module>
    from . import mavsdk_options_pb2 as mavsdk__options__pb2
  File "C:\Users\fclav\anaconda3\lib\site-packages\mavsdk\mavsdk_options_pb2.py", line 21, in <module>
    _ASYNCTYPE = DESCRIPTOR.enum_types_by_name['AsyncType']
AttributeError: 'NoneType' object has no attribute 'enum_types_by_name'
```


Updating protobuf to the last version (3.20.1) fix this issues