### PR TITLE
Fixed ComponentInformationServer key error

### DIFF
--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -205,7 +205,7 @@ class System:
     def component_information_server(self) -> component_information_server.ComponentInformationServer:
         if "component_information_server" not in self._plugins:
             raise RuntimeError(self.error_uninitialized("ComponentInformationServer"))
-        return self._plugins["component_informationServer"]
+        return self._plugins["component_information_server"]
 
     @property
     def core(self) -> core.Core:


### PR DESCRIPTION
The `component_information_server` property in `system.py` uses the wrong key when returning the value leading to a KeyError. This changes that key to the proper one.