### PR TITLE
fixing order of inputs in python example script

### DIFF
--- a/examples/manual_control.py
+++ b/examples/manual_control.py
@@ -89,7 +89,7 @@ async def manual_controls():
         yaw = float(input_list[3])
 
         await drone.manual_control.set_manual_control_input(
-            roll, pitch, throttle, yaw)
+            pitch, roll, throttle, yaw)
 
         await asyncio.sleep(0.1)
 


### PR DESCRIPTION
Think this needs to be fixed in the example -> [manual_control.py](https://github.com/mavlink/MAVSDK-Python/blob/2345933c5f14eb5da37569eb881fb9e86b68c4f4/examples/manual_control.py#L91)
The order of inputs _roll, pitch, throttle, yaw_ in the example seems to be incorrect.
The correct order needs to be _pitch, roll, throttle, yaw_ ([reference](https://github.com/mavlink/MAVSDK-Python/blob/2345933c5f14eb5da37569eb881fb9e86b68c4f4/mavsdk/manual_control.py#L254)).

Resolves #579 
