### PR TITLE
Simplify logging of mavsdk_server output

### DIFF
--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -74,7 +74,7 @@ class System:
     def __del__(self):
         self._stop_mavsdk_server()
 
-    async def connect(self, system_address=None):
+    async def connect(self, system_address=None, verbose=True):
         """
         Connect the System object to a remote system.
 
@@ -100,7 +100,7 @@ class System:
 
         if self._mavsdk_server_address is None:
             self._mavsdk_server_address = 'localhost'
-            self._server_process = self._start_mavsdk_server(system_address,self._port, self._sysid, self._compid)
+            self._server_process = self._start_mavsdk_server(system_address,self._port, self._sysid, self._compid, verbose)
 
         await self._init_plugins(self._mavsdk_server_address, self._port)
 
@@ -341,7 +341,7 @@ class System:
         return self._plugins["tune"]
 
     @staticmethod
-    def _start_mavsdk_server(system_address, port, sysid, compid):
+    def _start_mavsdk_server(system_address, port, sysid, compid, verbose=True):
         """
         Starts the gRPC server in a subprocess, listening on localhost:port
         port parameter can be specified now to allow multiple mavsdk servers to be spawned via code
@@ -370,7 +370,9 @@ class System:
                 if system_address:
                     bin_path_and_args.append(system_address)
                 p = subprocess.Popen(bin_path_and_args,
-                                     shell=False)
+                                     shell=False,
+                                     stdout=subprocess.DEVNULL if not verbose else None,
+                                     stderr=subprocess.DEVNULL if not verbose else None)
         except FileNotFoundError:
             print("""
 This installation does not provide an embedded 'mavsdk_server' binary.

--- a/mavsdk/system.py
+++ b/mavsdk/system.py
@@ -39,17 +39,6 @@ from . import tune
 
 from . import bin
 
-
-class _LoggingThread(threading.Thread):
-    def __init__(self, pipe, log_fn):
-        super().__init__()
-        self.pipe = pipe
-        self.log_fn = log_fn
-
-    def run(self):
-        for line in self.pipe:
-            self.log_fn(line.decode("utf-8").replace("\n", ""))
-
 class System:
     """
     Instantiate a System object, that will serve as a proxy to
@@ -381,13 +370,7 @@ class System:
                 if system_address:
                     bin_path_and_args.append(system_address)
                 p = subprocess.Popen(bin_path_and_args,
-                                     shell=False,
-                                     stdout=subprocess.PIPE,
-                                     stderr=subprocess.STDOUT)
-
-                logger = logging.getLogger(__name__)
-                log_thread = _LoggingThread(p.stdout, logger.debug)
-                log_thread.start()
+                                     shell=False)
         except FileNotFoundError:
             print("""
 This installation does not provide an embedded 'mavsdk_server' binary.


### PR DESCRIPTION
# Motivation
In #585 I described how logging output from the child process for `mavsdk_server` at only debug level hides useful errors from the user.

# Summary
This PR removes the logic for redirecting the subprocess stdout to the debugger and results in the mavsdk_server child process's stdout and stderr going straight to the main stdout/stderr.