### PR TITLE
Example-EV/GNSS fusion force switching

### DIFF
--- a/examples/ev_automation.py
+++ b/examples/ev_automation.py
@@ -1,0 +1,68 @@
+import asyncio
+from mavsdk import System
+
+async def set_params(system, params, announcement):
+    print(announcement)
+
+    async for _ in system.telemetry.landed_state():
+        break
+
+    for param, value in params:
+        await system.param.set_param_int(param, value)
+        await asyncio.sleep(5)
+
+    async for state in system.telemetry.landed_state():
+        break
+
+    print(f"Landed state: {state}")
+
+async def main():
+    drone = System()
+    await drone.connect(system_address="udp://:14540")
+
+    print("Waiting for drone to connect...")
+    async for state in drone.core.connection_state():
+        if state.is_connected:
+            print("-- Connected to drone!")
+            break
+
+    params_preflight = [
+        ("EKF2_HGT_REF", 0),
+        ("EKF2_EV_CTRL", 15),
+        ("EKF2_GPS_CTRL", 7)
+    ]
+    await set_params(drone, params_preflight, "Setting preflight parameters...")
+
+    # Wait for 5 seconds
+    await asyncio.sleep(5)
+
+    params_gps_required = [
+        ("EKF2_HGT_REF", 1),
+        ("EKF2_EV_CTRL", 0),
+        ("EKF2_GPS_CTRL", 7)
+    ]
+    await set_params(drone, params_gps_required, "Setting airborne (GPS Required) parameters...")
+
+    # Wait for 10 seconds
+    await asyncio.sleep(10)
+
+    params_ev_required = [
+        ("EKF2_HGT_REF", 3),
+        ("EKF2_EV_CTRL", 15),
+        ("EKF2_GPS_CTRL", 0)
+    ]
+    await set_params(drone, params_ev_required, "Setting airborne (EV Required) parameters...")
+
+    # Start the tasks to print flight mode and system status
+    print_mode_task = asyncio.ensure_future(print_mode(drone))
+    print_status_task = asyncio.ensure_future(print_status(drone))
+    running_tasks = [print_mode_task, print_status_task]
+
+    # Wait for the tasks to complete
+    await asyncio.gather(*running_tasks)
+
+    await drone.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/examples/ev_automation_keyboard.py
+++ b/examples/ev_automation_keyboard.py
@@ -1,0 +1,74 @@
+import asyncio
+from mavsdk import System
+
+async def set_params(system, params, announcement):
+    print(announcement)
+
+    async for _ in system.telemetry.landed_state():
+        break
+
+    for param, value in params:
+        await system.param.set_param_int(param, value)
+        await asyncio.sleep(5)
+
+    async for state in system.telemetry.landed_state():
+        break
+
+    print(f"Landed state: {state}")
+
+async def main():
+    drone = System()
+    await drone.connect(system_address="udp://:14540")
+
+    print("Waiting for drone to connect...")
+    async for state in drone.core.connection_state():
+        if state.is_connected:
+            print("-- Connected to drone!")
+            break
+
+    params_preflight = [
+        ("EKF2_HGT_REF", 0),
+        ("EKF2_EV_CTRL", 15),
+        ("EKF2_GPS_CTRL", 7)
+    ]
+    await set_params(drone, params_preflight, "Setting preflight parameters...")
+
+    params_gps_required = [
+        ("EKF2_HGT_REF", 1),
+        ("EKF2_EV_CTRL", 0),
+        ("EKF2_GPS_CTRL", 7)
+    ]
+
+    params_ev_required = [
+        ("EKF2_HGT_REF", 3),
+        ("EKF2_EV_CTRL", 15),
+        ("EKF2_GPS_CTRL", 0)
+    ]
+
+    while True:
+        async for is_armed in drone.telemetry.armed():
+            if not is_armed:
+                break
+
+            async for in_air in drone.telemetry.in_air():
+                if not in_air:
+                    break
+
+                mode = input("Enter mode ('EV', 'GPS', or 'Multi-fusion'): ")
+                if mode.lower() == "ev":
+                    await set_params(drone, params_ev_required, "Setting airborne (EV Required) parameters...")
+                    break
+                elif mode.lower() == "gps":
+                    await set_params(drone, params_gps_required, "Setting airborne (GPS Required) parameters...")
+                    break
+                elif mode.lower() == "multi-fusion":
+                    await set_params(drone, params_preflight, "Setting airborne (Multi-fusion) parameters...")
+                    break
+                else:
+                    print("Invalid mode. Please enter 'ev', 'gps', or 'multi-fusion'.")
+
+    await drone.telemetry().close()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+


### PR DESCRIPTION
@afwilkin has proposed that we can introduce a way with MAVSDK-Python example script to force switch between 3D-Pose fusion sources (VIO/GPS) for the special cases which these scenarios are needed. This also could be useful when users need to test their EV fusion and it healthy state. 
We are aware that EKF2 does this switching automatically but based on the above reasons we came to the point that it could also be useful to have specific examples to swap between fusion means. 
I have come to the point of two different kinds of examples, one with Keyboard input and another one with time-based method. 

@julianoes I would appreciate if you review this and share your ideas.
