### PR TITLE
Update follow_me_example to use MAVSDK v2

### DIFF
--- a/examples/follow_me_example.py
+++ b/examples/follow_me_example.py
@@ -7,14 +7,14 @@ from mavsdk import System
 from mavsdk.follow_me import (Config, FollowMeError, TargetLocation)
 
 
-default_height = 8.0  # in meters
+follow_height = 8.0  # in meters
 # distance between drone and target
 follow_distance = 2.0  # in meters
-
-# Direction relative to the Target
-# Options are NONE, FRONT, FRONT_LEFT, FRONT_RIGHT, BEHIND
-direction = Config.FollowDirection.BEHIND
 responsiveness = 0.02
+altitude_mode = Config.FollowAltitudeMode.TARGET_GPS
+max_follow_vel = 10
+# direction relative to the target
+follow_angle_deg = 0
 
 # This list contains fake location coordinates
 # (These coordinates are obtained from mission.py example)
@@ -45,7 +45,8 @@ async def run():
 
     # Follow me Mode requires some configuration to be done before starting
     # the mode
-    conf = Config(default_height, follow_distance, direction, responsiveness)
+    conf = Config(follow_height, follow_distance, responsiveness,
+        altitude_mode, max_follow_vel, follow_angle_deg)
     await drone.follow_me.set_config(conf)
 
     print("-- Taking Off")

--- a/examples/follow_me_example.py
+++ b/examples/follow_me_example.py
@@ -46,7 +46,7 @@ async def run():
     # Follow me Mode requires some configuration to be done before starting
     # the mode
     conf = Config(follow_height, follow_distance, responsiveness,
-        altitude_mode, max_follow_vel, follow_angle_deg)
+                  altitude_mode, max_follow_vel, follow_angle_deg)
     await drone.follow_me.set_config(conf)
 
     print("-- Taking Off")


### PR DESCRIPTION
## Changes

* Replace `direction = Config.FollowDirection.BEHIND` with `follow_angle_deg = 0` in `follow_me_example.py`
* Add new required args to follow_me `Config()`

### History

- [2020-08-16] **MAVSDK-Python** - `follow_me_example.py` added ([commit](https://github.com/mavlink/MAVSDK-Python/commit/8f916f0cd22e03c284419bacf6510a3efc8999d5))
- [2022-06-30] **MAVSDK-Proto** - `FollowDirection` enum and arg removed (https://github.com/mavlink/MAVSDK-Proto/pull/287#issuecomment-1132930474)
- [2024-01-27] **MAVSDK-Python** - `Config.FollowDirection` enum removed ([commit](https://github.com/mavlink/MAVSDK-Python/commit/8f8e81fb89914a2e98a9c9657230a08024edbb6c#diff-56d8fb7ac5ee5dc89721d8b0b2ada70565e3d2f314c500a05e0d2644de7378efL31))