### PR TITLE
useless-semicolon: `ruff check --select=E703 --fix`

### DIFF
--- a/mavsdk/action_server.py
+++ b/mavsdk/action_server.py
@@ -567,7 +567,7 @@ class ActionServer(AsyncBase):
                     raise ActionServerError(result, "arm_disarm()")
 
                 if result.result == ActionServerResult.Result.SUCCESS:
-                    arm_disarm_stream.cancel();
+                    arm_disarm_stream.cancel()
                     return
                 
 
@@ -606,7 +606,7 @@ class ActionServer(AsyncBase):
                     raise ActionServerError(result, "flight_mode_change()")
 
                 if result.result == ActionServerResult.Result.SUCCESS:
-                    flight_mode_change_stream.cancel();
+                    flight_mode_change_stream.cancel()
                     return
                 
 
@@ -645,7 +645,7 @@ class ActionServer(AsyncBase):
                     raise ActionServerError(result, "takeoff()")
 
                 if result.result == ActionServerResult.Result.SUCCESS:
-                    takeoff_stream.cancel();
+                    takeoff_stream.cancel()
                     return
                 
 
@@ -684,7 +684,7 @@ class ActionServer(AsyncBase):
                     raise ActionServerError(result, "land()")
 
                 if result.result == ActionServerResult.Result.SUCCESS:
-                    land_stream.cancel();
+                    land_stream.cancel()
                     return
                 
 
@@ -723,7 +723,7 @@ class ActionServer(AsyncBase):
                     raise ActionServerError(result, "reboot()")
 
                 if result.result == ActionServerResult.Result.SUCCESS:
-                    reboot_stream.cancel();
+                    reboot_stream.cancel()
                     return
                 
 
@@ -762,7 +762,7 @@ class ActionServer(AsyncBase):
                     raise ActionServerError(result, "shutdown()")
 
                 if result.result == ActionServerResult.Result.SUCCESS:
-                    shutdown_stream.cancel();
+                    shutdown_stream.cancel()
                     return
                 
 
@@ -801,7 +801,7 @@ class ActionServer(AsyncBase):
                     raise ActionServerError(result, "terminate()")
 
                 if result.result == ActionServerResult.Result.SUCCESS:
-                    terminate_stream.cancel();
+                    terminate_stream.cancel()
                     return
                 
 

--- a/mavsdk/calibration.py
+++ b/mavsdk/calibration.py
@@ -368,7 +368,7 @@ class Calibration(AsyncBase):
                     raise CalibrationError(result, "calibrate_gyro()")
 
                 if result.result == CalibrationResult.Result.SUCCESS:
-                    calibrate_gyro_stream.cancel();
+                    calibrate_gyro_stream.cancel()
                     return
                 
 
@@ -408,7 +408,7 @@ class Calibration(AsyncBase):
                     raise CalibrationError(result, "calibrate_accelerometer()")
 
                 if result.result == CalibrationResult.Result.SUCCESS:
-                    calibrate_accelerometer_stream.cancel();
+                    calibrate_accelerometer_stream.cancel()
                     return
                 
 
@@ -448,7 +448,7 @@ class Calibration(AsyncBase):
                     raise CalibrationError(result, "calibrate_magnetometer()")
 
                 if result.result == CalibrationResult.Result.SUCCESS:
-                    calibrate_magnetometer_stream.cancel();
+                    calibrate_magnetometer_stream.cancel()
                     return
                 
 
@@ -488,7 +488,7 @@ class Calibration(AsyncBase):
                     raise CalibrationError(result, "calibrate_level_horizon()")
 
                 if result.result == CalibrationResult.Result.SUCCESS:
-                    calibrate_level_horizon_stream.cancel();
+                    calibrate_level_horizon_stream.cancel()
                     return
                 
 
@@ -528,7 +528,7 @@ class Calibration(AsyncBase):
                     raise CalibrationError(result, "calibrate_gimbal_accelerometer()")
 
                 if result.result == CalibrationResult.Result.SUCCESS:
-                    calibrate_gimbal_accelerometer_stream.cancel();
+                    calibrate_gimbal_accelerometer_stream.cancel()
                     return
                 
 

--- a/mavsdk/ftp.py
+++ b/mavsdk/ftp.py
@@ -432,7 +432,7 @@ class Ftp(AsyncBase):
                     raise FtpError(result, "download()", remote_file_path, local_dir, use_burst)
 
                 if result.result == FtpResult.Result.SUCCESS:
-                    download_stream.cancel();
+                    download_stream.cancel()
                     return
                 
 
@@ -482,7 +482,7 @@ class Ftp(AsyncBase):
                     raise FtpError(result, "upload()", local_file_path, remote_dir)
 
                 if result.result == FtpResult.Result.SUCCESS:
-                    upload_stream.cancel();
+                    upload_stream.cancel()
                     return
                 
 

--- a/mavsdk/log_files.py
+++ b/mavsdk/log_files.py
@@ -422,7 +422,7 @@ class LogFiles(AsyncBase):
                     raise LogFilesError(result, "download_log_file()", entry, path)
 
                 if result.result == LogFilesResult.Result.SUCCESS:
-                    download_log_file_stream.cancel();
+                    download_log_file_stream.cancel()
                     return
                 
 

--- a/mavsdk/mission.py
+++ b/mavsdk/mission.py
@@ -1054,7 +1054,7 @@ class Mission(AsyncBase):
                     raise MissionError(result, "upload_mission_with_progress()", mission_plan)
 
                 if result.result == MissionResult.Result.SUCCESS:
-                    upload_mission_with_progress_stream.cancel();
+                    upload_mission_with_progress_stream.cancel()
                     return
                 
 
@@ -1148,7 +1148,7 @@ class Mission(AsyncBase):
                     raise MissionError(result, "download_mission_with_progress()")
 
                 if result.result == MissionResult.Result.SUCCESS:
-                    download_mission_with_progress_stream.cancel();
+                    download_mission_with_progress_stream.cancel()
                     return
                 
 

--- a/mavsdk/mission_raw_server.py
+++ b/mavsdk/mission_raw_server.py
@@ -658,7 +658,7 @@ class MissionRawServer(AsyncBase):
                     raise MissionRawServerError(result, "incoming_mission()")
 
                 if result.result == MissionRawServerResult.Result.SUCCESS:
-                    incoming_mission_stream.cancel();
+                    incoming_mission_stream.cancel()
                     return
                 
 


### PR DESCRIPTION
% `ruff check --select=E703 --fix`
```
Found 18 errors (18 fixed, 0 remaining).
```
% [`ruff rule E703`](https://docs.astral.sh/ruff/rules/useless-semicolon)
# useless-semicolon (E703)

Derived from the **pycodestyle** linter.

Fix is always available.

## What it does
Checks for statements that end with an unnecessary semicolon.

## Why is this bad?
A trailing semicolon is unnecessary and should be removed.

## Example
```python
do_four();  # useless semicolon
```

Use instead:
```python
do_four()
```
