### PR TITLE
`setup.py bdist_wheel` is deprecated and will be disabled in Oct. 2025

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.x
 
       - name: Install prerequisites
         run: |
@@ -194,7 +194,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.x
           architecture: ${{ matrix.arch }}
 
       - name: Install prerequisites

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Install prerequisites
         run: |
           python -m pip install -r requirements.txt
-          python -m pip install twine wheel
+          python -m pip install setuptools twine wheel
           python -m pip install --user delocate
 
       - name: Create wheel


### PR DESCRIPTION
Four instances:

https://github.com/mavlink/MAVSDK-Python/blob/edb9213199722a954e7d82f9c2f98df20d19f361/.github/workflows/main.yml#L40

https://github.com/mavlink/MAVSDK-Python/blob/edb9213199722a954e7d82f9c2f98df20d19f361/.github/workflows/main.yml#L107

https://github.com/mavlink/MAVSDK-Python/blob/edb9213199722a954e7d82f9c2f98df20d19f361/.github/workflows/main.yml#L156

https://github.com/mavlink/MAVSDK-Python/blob/edb9213199722a954e7d82f9c2f98df20d19f361/.github/workflows/main.yml#L207

In the macOS or Windows `Create wheel` section, please see the warning:
```
/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/setuptools/_distutils/cmd.py:90: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        By 2025-Oct-31, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
```