### PR TITLE
Update index.rst to include tip about enabling mavsdk-server debug output

### DIFF
--- a/mavsdk/source/index.rst
+++ b/mavsdk/source/index.rst
@@ -69,6 +69,14 @@ The examples assume that the embedded ``mavsdk_server`` binary can be run. In so
 Debug connection issues
 -----------------------
 
+.. note::
+   By default mavsdk-python will not print any output from mavsdk-server. If you are experiencing connection issues, it can pay to enable forwarding of the mavsdk-server output into the python console. You can do so with this piece of code at the top of your file:
+
+  .. code:: python
+
+    import logging
+    logging.basicConfig(level=logging.DEBUG)
+
 In order to get more debugging information, it is possible to run the mavsdk_server binary separately.
 
 For this case, let's assume the example was like this:


### PR DESCRIPTION
As discussed with @JonasVautherin on discord, here's the PR to add a brief tip to the docs teaching users how to enable debug output for mavlink-server, which can prove quite handy to figure out connection issues, or at least to verify that mavsdk-server is working even if the connection is not. 

Do note that this will not currently render correctly in discord. Due to https://github.com/github/markup/issues/1682 rendering of ``.. note`` syntax in github rst is currently broken. It should hopefully work fine on the website regardless. I have verified the syntax by pasting the affected section into https://waldyrious.net/rst-playground/ and it renders correctly there.