### PR TITLE
Autogenerate Python code without useless semicolons

### DIFF
--- a/other/templates/py/stream.j2
+++ b/other/templates/py/stream.j2
@@ -62,7 +62,7 @@ async def {{ name.lower_snake_case }}(self{% for param in params %}, {{ param.na
                 raise {{ plugin_name.upper_camel_case }}Error(result, "{{ name.lower_snake_case }}()"{% for param in params %}, {{ param.name.lower_snake_case }}{% endfor %})
 
             if result.result == {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
-                {{ name.lower_snake_case }}_stream.cancel();
+                {{ name.lower_snake_case }}_stream.cancel()
                 return
             {% endif %}
 


### PR DESCRIPTION
* #788

[ruff rule E703](https://docs.astral.sh/ruff/rules/useless-semicolon)