### PR TITLE
Remove unnecessary map usage using a list comprehension

### DIFF
--- a/mavsdk/camera.py
+++ b/mavsdk/camera.py
@@ -286,12 +286,7 @@ class SettingOptions:
             rpcSettingOptions.component_id,
             rpcSettingOptions.setting_id,
             rpcSettingOptions.setting_description,
-            list(
-                map(
-                    lambda elem: Option.translate_from_rpc(elem),
-                    rpcSettingOptions.options,
-                )
-            ),
+            [Option.translate_from_rpc(elem) for elem in rpcSettingOptions.options],
             rpcSettingOptions.is_range,
         )
 
@@ -1088,12 +1083,7 @@ class CurrentSettingsUpdate:
         """Translates a gRPC struct to the SDK equivalent"""
         return CurrentSettingsUpdate(
             rpcCurrentSettingsUpdate.component_id,
-            list(
-                map(
-                    lambda elem: Setting.translate_from_rpc(elem),
-                    rpcCurrentSettingsUpdate.current_settings,
-                )
-            ),
+            [Setting.translate_from_rpc(elem) for elem in rpcCurrentSettingsUpdate.current_settings],
         )
 
     def translate_to_rpc(self, rpcCurrentSettingsUpdate):
@@ -1157,12 +1147,7 @@ class PossibleSettingOptionsUpdate:
         """Translates a gRPC struct to the SDK equivalent"""
         return PossibleSettingOptionsUpdate(
             rpcPossibleSettingOptionsUpdate.component_id,
-            list(
-                map(
-                    lambda elem: SettingOptions.translate_from_rpc(elem),
-                    rpcPossibleSettingOptionsUpdate.setting_options,
-                )
-            ),
+            [SettingOptions.translate_from_rpc(elem) for elem in rpcPossibleSettingOptionsUpdate.setting_options],
         )
 
     def translate_to_rpc(self, rpcPossibleSettingOptionsUpdate):
@@ -1873,12 +1858,7 @@ class CameraList:
     def translate_from_rpc(rpcCameraList):
         """Translates a gRPC struct to the SDK equivalent"""
         return CameraList(
-            list(
-                map(
-                    lambda elem: Information.translate_from_rpc(elem),
-                    rpcCameraList.cameras,
-                )
-            )
+            [Information.translate_from_rpc(elem) for elem in rpcCameraList.cameras]
         )
 
     def translate_to_rpc(self, rpcCameraList):

--- a/mavsdk/events.py
+++ b/mavsdk/events.py
@@ -318,12 +318,7 @@ class HealthAndArmingCheckMode:
         return HealthAndArmingCheckMode(
             rpcHealthAndArmingCheckMode.mode_name,
             rpcHealthAndArmingCheckMode.can_arm_or_run,
-            list(
-                map(
-                    lambda elem: HealthAndArmingCheckProblem.translate_from_rpc(elem),
-                    rpcHealthAndArmingCheckMode.problems,
-                )
-            ),
+            [HealthAndArmingCheckProblem.translate_from_rpc(elem) for elem in rpcHealthAndArmingCheckMode.problems],
         )
 
     def translate_to_rpc(self, rpcHealthAndArmingCheckMode):
@@ -484,18 +479,8 @@ class HealthAndArmingCheckReport:
             HealthAndArmingCheckMode.translate_from_rpc(
                 rpcHealthAndArmingCheckReport.current_mode_intention
             ),
-            list(
-                map(
-                    lambda elem: HealthComponentReport.translate_from_rpc(elem),
-                    rpcHealthAndArmingCheckReport.health_components,
-                )
-            ),
-            list(
-                map(
-                    lambda elem: HealthAndArmingCheckProblem.translate_from_rpc(elem),
-                    rpcHealthAndArmingCheckReport.all_problems,
-                )
-            ),
+            [HealthComponentReport.translate_from_rpc(elem) for elem in rpcHealthAndArmingCheckReport.health_components],
+            [HealthAndArmingCheckProblem.translate_from_rpc(elem) for elem in rpcHealthAndArmingCheckReport.all_problems],
         )
 
     def translate_to_rpc(self, rpcHealthAndArmingCheckReport):

--- a/mavsdk/geofence.py
+++ b/mavsdk/geofence.py
@@ -139,7 +139,7 @@ class Polygon:
     def translate_from_rpc(rpcPolygon):
         """Translates a gRPC struct to the SDK equivalent"""
         return Polygon(
-            list(map(lambda elem: Point.translate_from_rpc(elem), rpcPolygon.points)),
+            [Point.translate_from_rpc(elem) for elem in rpcPolygon.points],
             FenceType.translate_from_rpc(rpcPolygon.fence_type),
         )
 
@@ -268,18 +268,8 @@ class GeofenceData:
     def translate_from_rpc(rpcGeofenceData):
         """Translates a gRPC struct to the SDK equivalent"""
         return GeofenceData(
-            list(
-                map(
-                    lambda elem: Polygon.translate_from_rpc(elem),
-                    rpcGeofenceData.polygons,
-                )
-            ),
-            list(
-                map(
-                    lambda elem: Circle.translate_from_rpc(elem),
-                    rpcGeofenceData.circles,
-                )
-            ),
+            [Polygon.translate_from_rpc(elem) for elem in rpcGeofenceData.polygons],
+            [Circle.translate_from_rpc(elem) for elem in rpcGeofenceData.circles],
         )
 
     def translate_to_rpc(self, rpcGeofenceData):

--- a/mavsdk/gimbal.py
+++ b/mavsdk/gimbal.py
@@ -594,12 +594,7 @@ class GimbalList:
     def translate_from_rpc(rpcGimbalList):
         """Translates a gRPC struct to the SDK equivalent"""
         return GimbalList(
-            list(
-                map(
-                    lambda elem: GimbalItem.translate_from_rpc(elem),
-                    rpcGimbalList.gimbals,
-                )
-            )
+            [GimbalItem.translate_from_rpc(elem) for elem in rpcGimbalList.gimbals]
         )
 
     def translate_to_rpc(self, rpcGimbalList):

--- a/mavsdk/mission.py
+++ b/mavsdk/mission.py
@@ -387,12 +387,7 @@ class MissionPlan:
     def translate_from_rpc(rpcMissionPlan):
         """Translates a gRPC struct to the SDK equivalent"""
         return MissionPlan(
-            list(
-                map(
-                    lambda elem: MissionItem.translate_from_rpc(elem),
-                    rpcMissionPlan.mission_items,
-                )
-            )
+            [MissionItem.translate_from_rpc(elem) for elem in rpcMissionPlan.mission_items]
         )
 
     def translate_to_rpc(self, rpcMissionPlan):

--- a/mavsdk/mission_raw.py
+++ b/mavsdk/mission_raw.py
@@ -284,24 +284,9 @@ class MissionImportData:
     def translate_from_rpc(rpcMissionImportData):
         """Translates a gRPC struct to the SDK equivalent"""
         return MissionImportData(
-            list(
-                map(
-                    lambda elem: MissionItem.translate_from_rpc(elem),
-                    rpcMissionImportData.mission_items,
-                )
-            ),
-            list(
-                map(
-                    lambda elem: MissionItem.translate_from_rpc(elem),
-                    rpcMissionImportData.geofence_items,
-                )
-            ),
-            list(
-                map(
-                    lambda elem: MissionItem.translate_from_rpc(elem),
-                    rpcMissionImportData.rally_items,
-                )
-            ),
+            [MissionItem.translate_from_rpc(elem) for elem in rpcMissionImportData.mission_items],
+            [MissionItem.translate_from_rpc(elem) for elem in rpcMissionImportData.geofence_items],
+            [MissionItem.translate_from_rpc(elem) for elem in rpcMissionImportData.rally_items],
         )
 
     def translate_to_rpc(self, rpcMissionImportData):

--- a/mavsdk/mission_raw_server.py
+++ b/mavsdk/mission_raw_server.py
@@ -214,12 +214,7 @@ class MissionPlan:
     def translate_from_rpc(rpcMissionPlan):
         """Translates a gRPC struct to the SDK equivalent"""
         return MissionPlan(
-            list(
-                map(
-                    lambda elem: MissionItem.translate_from_rpc(elem),
-                    rpcMissionPlan.mission_items,
-                )
-            )
+            [MissionItem.translate_from_rpc(elem) for elem in rpcMissionPlan.mission_items]
         )
 
     def translate_to_rpc(self, rpcMissionPlan):

--- a/mavsdk/offboard.py
+++ b/mavsdk/offboard.py
@@ -176,12 +176,7 @@ class ActuatorControl:
     def translate_from_rpc(rpcActuatorControl):
         """Translates a gRPC struct to the SDK equivalent"""
         return ActuatorControl(
-            list(
-                map(
-                    lambda elem: ActuatorControlGroup.translate_from_rpc(elem),
-                    rpcActuatorControl.groups,
-                )
-            )
+            [ActuatorControlGroup.translate_from_rpc(elem) for elem in rpcActuatorControl.groups]
         )
 
     def translate_to_rpc(self, rpcActuatorControl):

--- a/mavsdk/param.py
+++ b/mavsdk/param.py
@@ -244,24 +244,9 @@ class AllParams:
     def translate_from_rpc(rpcAllParams):
         """Translates a gRPC struct to the SDK equivalent"""
         return AllParams(
-            list(
-                map(
-                    lambda elem: IntParam.translate_from_rpc(elem),
-                    rpcAllParams.int_params,
-                )
-            ),
-            list(
-                map(
-                    lambda elem: FloatParam.translate_from_rpc(elem),
-                    rpcAllParams.float_params,
-                )
-            ),
-            list(
-                map(
-                    lambda elem: CustomParam.translate_from_rpc(elem),
-                    rpcAllParams.custom_params,
-                )
-            ),
+            [IntParam.translate_from_rpc(elem) for elem in rpcAllParams.int_params],
+            [FloatParam.translate_from_rpc(elem) for elem in rpcAllParams.float_params],
+            [CustomParam.translate_from_rpc(elem) for elem in rpcAllParams.custom_params],
         )
 
     def translate_to_rpc(self, rpcAllParams):

--- a/mavsdk/param_server.py
+++ b/mavsdk/param_server.py
@@ -209,24 +209,9 @@ class AllParams:
     def translate_from_rpc(rpcAllParams):
         """Translates a gRPC struct to the SDK equivalent"""
         return AllParams(
-            list(
-                map(
-                    lambda elem: IntParam.translate_from_rpc(elem),
-                    rpcAllParams.int_params,
-                )
-            ),
-            list(
-                map(
-                    lambda elem: FloatParam.translate_from_rpc(elem),
-                    rpcAllParams.float_params,
-                )
-            ),
-            list(
-                map(
-                    lambda elem: CustomParam.translate_from_rpc(elem),
-                    rpcAllParams.custom_params,
-                )
-            ),
+            [IntParam.translate_from_rpc(elem) for elem in rpcAllParams.int_params],
+            [FloatParam.translate_from_rpc(elem) for elem in rpcAllParams.float_params],
+            [CustomParam.translate_from_rpc(elem) for elem in rpcAllParams.custom_params],
         )
 
     def translate_to_rpc(self, rpcAllParams):

--- a/mavsdk/tune.py
+++ b/mavsdk/tune.py
@@ -236,12 +236,7 @@ class TuneDescription:
     def translate_from_rpc(rpcTuneDescription):
         """Translates a gRPC struct to the SDK equivalent"""
         return TuneDescription(
-            list(
-                map(
-                    lambda elem: SongElement.translate_from_rpc(elem),
-                    rpcTuneDescription.song_elements,
-                )
-            ),
+            [SongElement.translate_from_rpc(elem) for elem in rpcTuneDescription.song_elements],
             rpcTuneDescription.tempo,
         )
 


### PR DESCRIPTION
We can postprocess generation with ruff check like:
* https://github.com/mavlink/MAVSDK-Python/blob/5717d9e7f196679bfda485b3a2f1df9db18e812c/other/tools/run_protoc.sh#L102

Or we could have done that rewriting in:
 * #792 

---
% `ruff check --select=C417 --fix --unsafe-fixes`
```
Found 24 errors (24 fixed, 0 remaining).
```
% `ruff rule C417`
# unnecessary-map (C417)

Derived from the **flake8-comprehensions** linter.

Fix is sometimes available.

## What it does
Checks for unnecessary `map()` calls with lambda functions.

## Why is this bad?
Using `map(func, iterable)` when `func` is a lambda is slower than
using a generator expression or a comprehension, as the latter approach
avoids the function call overhead, in addition to being more readable.

This rule also applies to `map()` calls within `list()`, `set()`, and
`dict()` calls. For example:

- Instead of `list(map(lambda num: num * 2, nums))`, use
  `[num * 2 for num in nums]`.
- Instead of `set(map(lambda num: num % 2 == 0, nums))`, use
  `{num % 2 == 0 for num in nums}`.
- Instead of `dict(map(lambda v: (v, v ** 2), values))`, use
  `{v: v ** 2 for v in values}`.

## Example
```python
map(lambda x: x + 1, iterable)
```

Use instead:
```python
(x + 1 for x in iterable)
```

## Fix safety
This rule's fix is marked as unsafe, as it may occasionally drop comments
when rewriting the call. In most cases, though, comments will be preserved.
