### PR TITLE
Do not generate unnecessary map usage

### DIFF
--- a/other/templates/py/stream.j2
+++ b/other/templates/py/stream.j2
@@ -73,7 +73,7 @@ async def {{ name.lower_snake_case }}(self{% for param in params %}, {{ param.na
         {%- elif not return_type.is_primitive and not return_type.is_repeated %}
             yield {{ return_type.name }}.translate_from_rpc(response.{{ return_name.lower_snake_case }})
         {%- elif not return_type.is_primitive and return_type.is_repeated %}
-            yield list(map(lambda x : {{ return_type.inner_name }}.translate_from_rpc(x), response.{{ return_name.lower_snake_case }}))
+            yield [{{ return_type.inner_name }}.translate_from_rpc(x) for x in response.{{ return_name.lower_snake_case }}]
         {%- endif %}
     finally:
         {{ name.lower_snake_case }}_stream.cancel()


### PR DESCRIPTION
Fix #795 in code generation instead of postprocessing with `ruff`.
* #795 