### PR TITLE
fix(windows): ship the right mavsdk_server for each architecture

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Create wheel
         run: |
-          set MAVSDK_SERVER_ARCH=${{ matrix.arch }}
+          $env:MAVSDK_SERVER_ARCH = "${{ matrix.arch }}"
           python3 setup.py bdist_wheel
           Dir "dist/" | rename-item -NewName {$_.name -replace '-any.whl','-${{ matrix.wheel_arch }}.whl'}
 

--- a/setup.py
+++ b/setup.py
@@ -79,12 +79,14 @@ class custom_build(build):
             )
 
         elif platform.system() == "Windows" and "MAVSDK_SERVER_ARCH" in os.environ:
+            # The released Windows assets are named with a .exe suffix, e.g.
+            # mavsdk_server_win_x86.exe -- without it the download 404s.
             if os.environ["MAVSDK_SERVER_ARCH"] == "x86":
-                return "win_x86"
+                return "win_x86.exe"
             elif os.environ["MAVSDK_SERVER_ARCH"] == "x64":
-                return "win_x64"
+                return "win_x64.exe"
             elif os.environ["MAVSDK_SERVER_ARCH"] == "arm64":
-                return "win_arm64"
+                return "win_arm64.exe"
             else:
                 raise NotImplementedError(
                     "Error: unknown MAVSDK_SERVER_ARCH: "


### PR DESCRIPTION
The `win32` and `win_arm64` wheels have been shipping the **x64** `mavsdk_server.exe`.

## Evidence

Downloaded the three published `mavsdk` 3.17.2 Windows wheels from PyPI and extracted `mavsdk/bin/mavsdk_server.exe` from each:

| Wheel | sha256 of extracted `mavsdk_server.exe` | PE machine |
|---|---|---|
| `win32` | `f678ba02…16c381` | `0x8664` (AMD64) |
| `win_amd64` | `f678ba02…16c381` | `0x8664` (AMD64) |
| `win_arm64` | `f678ba02…16c381` | `0x8664` (AMD64) |

Byte-identical in all three (49,082,880 bytes each). So the `win32` wheel ships a 64-bit binary labelled 32-bit, and the `win_arm64` wheel ships x64.

## Cause

Two bugs combine:

**1. The env var never reaches `setup.py`.** The Windows job does:

```powershell
set MAVSDK_SERVER_ARCH=${{ matrix.arch }}
```

That is cmd syntax. The step runs under `pwsh`, where `set` is an alias for `Set-Variable`, so this is parsed as a single positional argument and never sets the environment variable. The `"MAVSDK_SERVER_ARCH" in os.environ` guard in `platform_suffix` is therefore always false on Windows, and it falls through to the fallback branch — which returns `win_x64.exe` for every matrix entry.

**2. The explicit-arch branch is missing the `.exe` suffix.** It returns `win_x86` / `win_x64` / `win_arm64`, but the release assets are named `mavsdk_server_win_x86.exe` etc. Fixing only bug 1 would have swapped a silently-wrong binary for a hard 404 at build time:

```
mavsdk_server_win_x86      -> 404
mavsdk_server_win_x86.exe  -> 200
```

Note the fallback branch already had the suffix right, which is why the wrong-but-working path stayed wrong-but-working.

## Fix

- Use `$env:MAVSDK_SERVER_ARCH = "..."` in the workflow.
- Append `.exe` to the three Windows return values in `platform_suffix`.

## Verification

All three per-arch assets exist upstream. Simulating the fixed code path with `platform.system()` stubbed to `Windows` gives, for the `MAVSDK_SERVER_VERSION` tag:

```
   x86 -> win_x86.exe     HTTP 200  OK
   x64 -> win_x64.exe     HTTP 200  OK
 arm64 -> win_arm64.exe   HTTP 200  OK
```

Worth watching the `Create wheel` step logs on this PR — `download_mavsdk_server` prints the URL it fetches, so the three Windows jobs should now each print a different one.